### PR TITLE
Filter more efficient by finding ipv6 hosts first, and filter ipv4 by ipv6.

### DIFF
--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -1032,9 +1032,8 @@ def _dhcpv6_hosts_by_ipv4(iprange):
 
     def _unique_host_ids(qs):
         qs = qs.select_related('host')
-        host_ids = [ip.host.id for ip in qs]
-        host_once = [host_id for host_id, count in Counter(host_ids).items() if count == 1]
-        return host_once
+        counter = Counter([ip.host.id for ip in qs])
+        return [host_id for host_id, count in counter.items() if count == 1]
 
     ipv6 = _get_ips_by_range('::/0')
     qs = ipv6.filter(macaddress='').filter(host__in=_unique_host_ids(ipv6))

--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -1037,15 +1037,14 @@ def _dhcpv6_hosts_by_ipv4(iprange):
 
     ipv6 = _get_ips_by_range('::/0')
     ipv6 = ipv6.filter(macaddress='').filter(host__in=_unique_host_ids(ipv6))
-    ipv6_host_once = _unique_host_ids(ipv6)
-    ipv6 = ipv6.filter(host__in=ipv6_host_once)
+    ipv6_hosts = _unique_host_ids(ipv6)
 
-    ipv4 = _get_ips_by_range(iprange).filter(host__in=ipv6_host_once)
-    ipv4 = ipv4.exclude(macaddress='')
-    ipv4_host_once = _unique_host_ids(ipv4)
+    ipv4 = _get_ips_by_range(iprange).filter(host__in=ipv6_hosts)
+    ipv4 = ipv4.exclude(macaddress='').filter(host__in=_unique_host_ids(ipv4))
+    ipv4_hosts = _unique_host_ids(ipv4)
     ipv4_host2mac = {hostname: mac for hostname, mac in
                      ipv4.values_list('host__name', 'macaddress')}
-    ipv6 = ipv6.filter(host__in=ipv4_host_once).order_by('ipaddress')
+    ipv6 = ipv6.filter(host__in=ipv4_hosts).order_by('ipaddress')
     ret = []
     for values in ipv6.values('host__name', 'host__zone__name', 'ipaddress'):
         values['macaddress'] = ipv4_host2mac[values['host__name']]

--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -1036,12 +1036,14 @@ def _dhcpv6_hosts_by_ipv4(iprange):
         return host_once
 
     ipv6 = _get_ips_by_range('::/0')
-    ipv6 = ipv6.filter(macaddress='').filter(host__in=_unique_host_ids(ipv6))
-    ipv6_hosts = _unique_host_ids(ipv6)
+    qs = ipv6.filter(macaddress='').filter(host__in=_unique_host_ids(ipv6))
+    ipv6_hosts = _unique_host_ids(qs)
 
-    ipv4 = _get_ips_by_range(iprange).filter(host__in=ipv6_hosts)
-    ipv4 = ipv4.exclude(macaddress='').filter(host__in=_unique_host_ids(ipv4))
-    ipv4_hosts = _unique_host_ids(ipv4)
+    ipv4 = _get_ips_by_range(iprange)
+    qs = ipv4.filter(host__in=ipv6_hosts)
+    qs = qs.exclude(macaddress='').filter(host__in=_unique_host_ids(qs))
+    ipv4_hosts = _unique_host_ids(qs)
+    ipv4 = ipv4.filter(host__in=ipv4_hosts)
     ipv4_host2mac = {hostname: mac for hostname, mac in
                      ipv4.values_list('host__name', 'macaddress')}
     ipv6 = ipv6.filter(host__in=ipv4_hosts).order_by('ipaddress')

--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -1025,8 +1025,9 @@ class DhcpHostsByRange(generics.GenericAPIView):
 
 def _dhcpv6_hosts_by_ipv4(iprange):
     """
-    Find all hosts which have both an ipv4 and ipv6 address,
-    and where the ipv4 address has a mac assosicated.
+    Find all hosts which have only one ipv4 and one ipv6 address,
+    and where the ipv4 address has a mac associated and the
+    ipv6 address has not.
     """
 
     def _unique_host_ids(qs):


### PR DESCRIPTION
As ipv4 is vastly more widespread than ipv6, filter ipv4 by ipv6, instead
of the other way around.

Also forgot a select_related('host') for the ipv6 queryset, which made it quite
slow.

Solves everything except vlan-check in #353.