### PR TITLE
Add PtrOverrides to used/unused/counts etc for Network.

### DIFF
--- a/mreg/api/v1/serializers.py
+++ b/mreg/api/v1/serializers.py
@@ -113,8 +113,8 @@ class IpaddressSerializer(ValidationMixin, serializers.ModelSerializer):
                 # Allow mac to be bound to both an ipv4 and ipv6 address on the same vlan
                 if ipversion != network.network.version:
                     continue
-                ips = network._get_used_ipaddresses()
-                _raise_if_mac_found(ips, mac)
+                qs = network._used_ipaddresses()
+                _raise_if_mac_found(qs, mac)
         return data
 
 

--- a/mreg/api/v1/tests/test_networks.py
+++ b/mreg/api/v1/tests/test_networks.py
@@ -248,8 +248,9 @@ class NetworksTestCase(MregAPITestCase):
     def test_networks_get_usedcount_200_ok(self):
         """GET on /networks/<ip/mask>/used_count return 200 ok and data."""
         Ipaddress.objects.create(host=self.host_one, ipaddress='10.0.0.17')
+        PtrOverride.objects.create(host=self.host_one, ipaddress='10.0.0.18')
         response = self.assert_get('/networks/%s/used_count' % self.network_sample.network)
-        self.assertEqual(response.data, 1)
+        self.assertEqual(response.data, 2)
 
     def test_ipv6_networks_get_usedcount_200_ok(self):
         """GET on /networks/<ipv6/mask>/used_count return 200 ok and data."""
@@ -282,8 +283,9 @@ class NetworksTestCase(MregAPITestCase):
     def test_networks_get_unusedcount_200_ok(self):
         """GET on /networks/<ip/mask>/unused_count should return 200 ok and data."""
         Ipaddress.objects.create(host=self.host_one, ipaddress='10.0.0.17')
+        Ipaddress.objects.create(host=self.host_one, ipaddress='10.0.0.18')
         response = self.assert_get('/networks/%s/unused_count' % self.network_sample.network)
-        self.assertEqual(response.data, 250)
+        self.assertEqual(response.data, 249)
 
     def test_ipv6_networks_get_unusedcount_200_ok(self):
         """GET on /networks/<ipv6/mask>/unused_count should return 200 ok and data."""


### PR DESCRIPTION
Sometimes ipaddresses can be used by a PtrOverride object without
one or more Ipaddress objects for the same ipaddress, so cope with that.

Resolves #361.