### PR TITLE
Update zone for existing hosts when adding a zone

### DIFF
--- a/mreg/api/v1/tests/tests_zones.py
+++ b/mreg/api/v1/tests/tests_zones.py
@@ -349,6 +349,23 @@ class ZonesForwardDelegationTestCase(MregAPITestCase):
         _test('host.delegated.example.org', 'delegated.example.org', 'delegation')
         _test('delegated.example.org', 'delegated.example.org', 'delegation')
 
+    def test_delegation_patch_modifies_zone_updated_at(self):
+        # add a delegation
+        path = self.del_path('example.org')
+        data = {'name': 'delegated.example.org',
+                'nameservers': ['ns1.example.org', 'ns1.delegated.example.org']}
+        self.assert_post(path, data)
+        # get the "before" timestamp
+        data = self.assert_get(self.zonepath + 'example.org').json()
+        before = data['updated_at']
+        # patch the delegation
+        self.assert_patch(path + "delegated.example.org", {'comment': 'new comment'})
+        # get the "after" timestamp
+        data = self.assert_get(self.zonepath + 'example.org').json()
+        after = data['updated_at']
+        # the timestamp should have been updated
+        self.assertLess(before, after)
+
 
 class ZonesReverseDelegationTestCase(MregAPITestCase):
     """ This class defines test testsuite for api/zones/reverse/<name>/delegations/

--- a/mreg/api/v1/tests/tests_zones.py
+++ b/mreg/api/v1/tests/tests_zones.py
@@ -349,23 +349,6 @@ class ZonesForwardDelegationTestCase(MregAPITestCase):
         _test('host.delegated.example.org', 'delegated.example.org', 'delegation')
         _test('delegated.example.org', 'delegated.example.org', 'delegation')
 
-    def test_delegation_patch_modifies_zone_updated_at(self):
-        # add a delegation
-        path = self.del_path('example.org')
-        data = {'name': 'delegated.example.org',
-                'nameservers': ['ns1.example.org', 'ns1.delegated.example.org']}
-        self.assert_post(path, data)
-        # get the "before" timestamp
-        data = self.assert_get(self.zonepath + 'example.org').json()
-        before = data['updated_at']
-        # patch the delegation
-        self.assert_patch(path + "delegated.example.org", {'comment': 'new comment'})
-        # get the "after" timestamp
-        data = self.assert_get(self.zonepath + 'example.org').json()
-        after = data['updated_at']
-        # the timestamp should have been updated
-        self.assertLess(before, after)
-
 
 class ZonesReverseDelegationTestCase(MregAPITestCase):
     """ This class defines test testsuite for api/zones/reverse/<name>/delegations/

--- a/mreg/api/v1/views_zones.py
+++ b/mreg/api/v1/views_zones.py
@@ -261,10 +261,6 @@ class ZoneDelegationDetail(MregRetrieveUpdateDestroyAPIView):
 
     def patch(self, request, *args, **kwargs):
         if "comment" in request.data and len(request.data) == 1:
-            # Also update the parent zone's updated attribute
-            self.get_queryset()
-            self.parentzone.updated = True
-            self.parentzone.save()
             return super().patch(request, *args, **kwargs)
         else:
             content = {'ERROR': 'Only allowed to change comment'}

--- a/mreg/api/v1/views_zones.py
+++ b/mreg/api/v1/views_zones.py
@@ -261,6 +261,10 @@ class ZoneDelegationDetail(MregRetrieveUpdateDestroyAPIView):
 
     def patch(self, request, *args, **kwargs):
         if "comment" in request.data and len(request.data) == 1:
+            # Also update the parent zone's updated attribute
+            self.get_queryset()
+            self.parentzone.updated = True
+            self.parentzone.save()
             return super().patch(request, *args, **kwargs)
         else:
             content = {'ERROR': 'Only allowed to change comment'}

--- a/mreg/signals.py
+++ b/mreg/signals.py
@@ -288,6 +288,8 @@ def add_auto_txt_records_on_new_host(sender, instance, created, **kwargs):
 
 @receiver(post_save, sender=ForwardZone)
 def update_hosts_when_zone_is_added(sender, instance, created, **kwargs):
+    """When a zone is created, any existing hosts that would be in that zone
+       must be updated."""
     if created:
         zonename = "." + instance.name
         for h in Host.objects.filter(name__endswith = zonename):

--- a/mreg/tests.py
+++ b/mreg/tests.py
@@ -796,8 +796,8 @@ class ModelForwardZoneTestCase(TestCase):
         self.assertEqual(old_suat, zone.serialno_updated_at)
 
     def test_update_hosts_when_zone_added(self):
-        # When you add a Zone, existing Host objects that have a domain
-        # that matches the Zone should be put in that zone.
+        """When you add a Zone, existing Host objects that have a domain
+           that matches the Zone should be put in that zone."""
         host = Host.objects.create(name='foo.'+self.zone_sample.name)
         host.save()
         # Here's another host in a sub-zone, it should not be touched...

--- a/mreg/tests.py
+++ b/mreg/tests.py
@@ -795,6 +795,22 @@ class ModelForwardZoneTestCase(TestCase):
         self.assertEqual(old_serial, zone.serialno)
         self.assertEqual(old_suat, zone.serialno_updated_at)
 
+    def test_update_hosts_when_zone_added(self):
+        # When you add a Zone, existing Host objects that have a domain
+        # that matches the Zone should be put in that zone.
+        host = Host.objects.create(name='foo.'+self.zone_sample.name)
+        host.save()
+        # Here's another host in a sub-zone, it should not be touched...
+        otherhost = Host.objects.create(name='foo.bar.'+self.zone_sample.name)
+        otherhost.save()
+        # Save the zone. This should trigger code that updates the host
+        self.zone_sample.save()
+        saved = Host.objects.get(name=host.name)
+        self.assertNotEqual(saved.zone, None)
+        self.assertEqual(saved.zone.name, self.zone_sample.name)
+        # Verify that otherhost wasn't changed
+        meh = Host.objects.get(name=otherhost.name)
+        self.assertEqual(meh.zone, None)
 
 class ModelReverseZoneTestCase(TestCase):
     """This class defines the test suite for the ReverseZone model."""


### PR DESCRIPTION
Also, update the zone timestamp when a delegation is patched.