### PR TITLE
Fix Travis CI randomly failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,13 @@ addons:
       - postgresql-client-11
 env:
   global:
-    - PGPORT=5433
+    - PGPORT=5432
 before_install:
   - sudo systemctl stop postgresql || sudo journalctl -xe -n 20 -u postgresql
-  - sudo sed -i 's/peer/trust/' /etc/postgresql/11/main/pg_hba.conf
-  - sudo cat /etc/postgresql/11/main/pg_hba.conf
+  - sudo sed -i 's/(peer|md5)/trust/' /etc/postgresql/11/main/pg_hba.conf
+  - sudo cat /etc/postgresql/11/main/pg_hba.conf | grep -ve '^#'
   - sudo systemctl start postgresql@11-main || sudo journalctl -xe -n 20 -u postgresql
   - sleep 2
-  - sudo systemctl status postgresql
 before_script:
   - psql -c 'CREATE EXTENSION citext;' -U postgres template1
   - psql -c 'CREATE DATABASE travisci;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,14 @@ services:
   - postgresql
 addons:
   postgresql: "11"
+  apt:
+    packages:
+      - postgresql-11
+      - postgresql-client-11
+env:
+  global:
+    - PGPORT=5433
 before_install:
-  - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -sc)-pgdg main" > /etc/apt/sources.list.d/PostgreSQL.list'
-  - sudo apt-get update
-  - sudo apt-get install -y postgresql-11
   - sudo grep postgres /etc/postgresql/11/main/pg_hba.conf
   - sudo sed -i 's/local\s\+all\s\+postgres\s\+peer/local all postgres trust/' /etc/postgresql/11/main/pg_hba.conf 
   - sudo grep postgres /etc/postgresql/11/main/pg_hba.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - PGPORT=5433
 before_install:
   - sudo systemctl stop postgresql || sudo journalctl -xe -n 20 -u postgresql
-  - sudo sed -i 's/local\s\+all\s\+postgres\s\+peer/local all postgres trust/' /etc/postgresql/11/main/pg_hba.conf 
+  - sudo sed -i 's/peer/trust/' /etc/postgresql/11/main/pg_hba.conf
   - sudo systemctl start postgresql@11-main || sudo journalctl -xe -n 20 -u postgresql
   - sleep 2
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ env:
   global:
     - PGPORT=5433
 before_install:
-  - sudo grep postgres /etc/postgresql/11/main/pg_hba.conf
+  - sudo systemctl stop postgresql || sudo journalctl -xe -n 20 -u postgresql
   - sudo sed -i 's/local\s\+all\s\+postgres\s\+peer/local all postgres trust/' /etc/postgresql/11/main/pg_hba.conf 
-  - sudo grep postgres /etc/postgresql/11/main/pg_hba.conf
-  - sudo systemctl restart postgresql@11-main || sudo journalctl -xe -n 20 -u postgresql
+  - sudo systemctl start postgresql@11-main || sudo journalctl -xe -n 20 -u postgresql
   - sleep 2
 before_script:
   - psql -c 'CREATE EXTENSION citext;' -U postgres template1

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 before_install:
   - sudo systemctl stop postgresql || sudo journalctl -xe -n 20 -u postgresql
   - sudo sed -i -r 's/(peer|md5)/trust/' /etc/postgresql/11/main/pg_hba.conf
-  - sudo cat /etc/postgresql/11/main/pg_hba.conf | grep -ve '^#'
+  - sudo cat /etc/postgresql/11/main/pg_hba.conf | grep -vP '^(#|\s*$)'
   - sudo systemctl start postgresql@11-main || sudo journalctl -xe -n 20 -u postgresql
   - sleep 2
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
       - postgresql-client-11
 env:
   global:
-    - PGPORT=5432
+    - PGPORT=5433
 before_install:
   - sudo systemctl stop postgresql || sudo journalctl -xe -n 20 -u postgresql
   - sudo sed -i -r 's/(peer|md5)/trust/' /etc/postgresql/11/main/pg_hba.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - PGPORT=5432
 before_install:
   - sudo systemctl stop postgresql || sudo journalctl -xe -n 20 -u postgresql
-  - sudo sed -i 's/(peer|md5)/trust/' /etc/postgresql/11/main/pg_hba.conf
+  - sudo sed -i -r 's/(peer|md5)/trust/' /etc/postgresql/11/main/pg_hba.conf
   - sudo cat /etc/postgresql/11/main/pg_hba.conf | grep -ve '^#'
   - sudo systemctl start postgresql@11-main || sudo journalctl -xe -n 20 -u postgresql
   - sleep 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ env:
 before_install:
   - sudo systemctl stop postgresql || sudo journalctl -xe -n 20 -u postgresql
   - sudo sed -i 's/peer/trust/' /etc/postgresql/11/main/pg_hba.conf
+  - sudo cat /etc/postgresql/11/main/pg_hba.conf
   - sudo systemctl start postgresql@11-main || sudo journalctl -xe -n 20 -u postgresql
   - sleep 2
+  - sudo systemctl status postgresql
 before_script:
   - psql -c 'CREATE EXTENSION citext;' -U postgres template1
   - psql -c 'CREATE DATABASE travisci;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,12 @@ env:
   global:
     - PGPORT=5433
 before_install:
+  - sudo systemctl stop postgresql-9.service
+  - sudo systemctl stop postgresql-10.service
   - sudo grep postgres /etc/postgresql/11/main/pg_hba.conf
   - sudo sed -i 's/local\s\+all\s\+postgres\s\+peer/local all postgres trust/' /etc/postgresql/11/main/pg_hba.conf 
   - sudo grep postgres /etc/postgresql/11/main/pg_hba.conf
-  - sudo systemctl restart postgresql.service || sudo journalctl -xe -n 20 -u postgresql.service
+  - sudo systemctl restart postgresql-11.service || sudo journalctl -xe -n 20 -u postgresql
   - sleep 2
 before_script:
   - psql -c 'CREATE EXTENSION citext;' -U postgres template1

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,10 @@ env:
   global:
     - PGPORT=5433
 before_install:
-  - sudo systemctl stop postgresql-9.service
-  - sudo systemctl stop postgresql-10.service
   - sudo grep postgres /etc/postgresql/11/main/pg_hba.conf
   - sudo sed -i 's/local\s\+all\s\+postgres\s\+peer/local all postgres trust/' /etc/postgresql/11/main/pg_hba.conf 
   - sudo grep postgres /etc/postgresql/11/main/pg_hba.conf
-  - sudo systemctl restart postgresql-11.service || sudo journalctl -xe -n 20 -u postgresql
+  - sudo systemctl restart postgresql@11-main || sudo journalctl -xe -n 20 -u postgresql
   - sleep 2
 before_script:
   - psql -c 'CREATE EXTENSION citext;' -U postgres template1

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -117,7 +117,7 @@ if 'TRAVIS' in os.environ:
             'USER':     'postgres',
             'PASSWORD': '',
             'HOST':     'localhost',
-            'PORT':     '',
+            'PORT':     '5433',
         }
     }
 

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -117,7 +117,7 @@ if 'TRAVIS' in os.environ:
             'USER':     'postgres',
             'PASSWORD': '',
             'HOST':     'localhost',
-            'PORT':     '5433',
+            'PORT':     '5432',
         }
     }
 

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -117,7 +117,7 @@ if 'TRAVIS' in os.environ:
             'USER':     'postgres',
             'PASSWORD': '',
             'HOST':     'localhost',
-            'PORT':     '5432',
+            'PORT':     '5433',
         }
     }
 


### PR DESCRIPTION
This PR changes `.travis.yml` in the following ways:
- Uses Travis' own directives for installing PostgreSQL 11, removes all the `apt` commands
- Uses port 5433, for some reason it doesn't work with the default port
- Ensures that only PostgreSQL 11 is running, other versions are stopped

Resolves #399.

When merging this PR, please use a _Squash commit_.