### PR TITLE
Migrate from Swagger to OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,6 @@ To run the tests for the system, simply run
 #### Logging
 * [django-logging](https://github.com/cipriantarta/django-logging)
 
-#### API Documentation
-* [Django REST Swagger](https://marcgibbons.com/django-rest-swagger/)
-
 ## Local Settings
 To override entries in mregsite/settings.py, create a file mregsite/local_settings.py and add the entries there.
 For example, the default database setup in settings.py uses sqlite3, but if you set up your postgres database

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -57,7 +57,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
-    'rest_framework_swagger',
     'rest_framework.authtoken',
     'django_logging',
     'netfields',
@@ -169,11 +168,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'mreg.api.permissions.IsAuthenticatedAndReadOnly',
     ),
-    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
-}
-
-SWAGGER_SETTINGS = {
-    'USE_SESSION_AUTH': False,
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.openapi.AutoSchema',
 }
 
 # This setting must be defined for mreg.api.permissions.IsInRequiredGroup

--- a/mregsite/urls.py
+++ b/mregsite/urls.py
@@ -3,10 +3,10 @@ from django.urls import include, path
 
 from mreg.api.v1 import views
 
-from rest_framework_swagger.views import get_swagger_view
+from rest_framework.schemas import get_schema_view
 
 # Schema view for swagger api documentation
-schema_view = get_swagger_view(title='mreg API')
+schema_view = get_schema_view(title='mreg API')
 
 urlpatterns = [
     path('api/', include('mreg.api.urls')),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 Django==3.0.7
-djangorestframework==3.11.0
+djangorestframework==3.11.1
 django-auth-ldap==2.1.0
 django-logging-json==1.15
 django-netfields==1.2.2
-django-rest-swagger==2.2.0
 django-url-filter==0.3.14
 gunicorn==20.0.4
 idna==2.8


### PR DESCRIPTION
OpenAPI support is built-in to newer versions of djangorestframework, and coreapi/swagger is deprecated.