### PR TITLE
Allow MAC address to be specified in various formats

### DIFF
--- a/mreg/api/v1/serializers.py
+++ b/mreg/api/v1/serializers.py
@@ -11,8 +11,8 @@ from mreg.models import (Cname, ForwardZone, ForwardZoneDelegation,
                          Mx, NameServer, Naptr,
                          NetGroupRegexPermission, Network, PtrOverride,
                          ReverseZone, ReverseZoneDelegation, Srv, Sshfp, Txt)
-from mreg.utils import nonify
-from mreg.validators import validate_keys
+from mreg.utils import (nonify, normalize_mac)
+from mreg.validators import (validate_keys, validate_normalizeable_mac_address)
 
 
 class ValidationMixin:
@@ -64,8 +64,20 @@ class HinfoSerializer(ValidationMixin, serializers.ModelSerializer):
         model = Hinfo
         fields = '__all__'
 
+class MacAddressSerializerField(serializers.Field):
+    """Normalize the provided MAC address into the common format."""
+    def to_representation(self, obj):
+        return obj
+
+    def to_internal_value(self, data):
+        if data and isinstance(data, str):
+            validate_normalizeable_mac_address(data)
+            return normalize_mac(data)
+        return data
 
 class IpaddressSerializer(ValidationMixin, serializers.ModelSerializer):
+    macaddress = MacAddressSerializerField(required=False)
+
     class Meta:
         model = Ipaddress
         fields = '__all__'

--- a/mreg/api/v1/tests/tests.py
+++ b/mreg/api/v1/tests/tests.py
@@ -1173,6 +1173,16 @@ class APIMACaddressTestCase(MregAPITestCase):
         self.assert_patch_and_400('/ipaddresses/%s' % self.ipaddress_one.id,
                                   patch_mac_in_use)
 
+    def test_mac_patch_formats_204_ok(self):
+        """ Patch an IP with MAC address in various formats. """
+        def _assert(mac):
+            self.assert_patch('/ipaddresses/%s' % self.ipaddress_one.id,
+                              {'macaddress': mac})
+        _assert('AA:BB:CC:00:11:22')
+        _assert('AA-BB-CC-00-11-22')
+        _assert('aabb.cc00.1122')
+        _assert('aa:bb:cc:00:11:22')
+
     def test_mac_patch_invalid_mac_400_bad_request(self):
         """ Patch an IP with invalid MAC should return 400 bad request."""
         def _assert(mac):
@@ -1180,7 +1190,7 @@ class APIMACaddressTestCase(MregAPITestCase):
                                       {'macaddress': mac})
         _assert('00:00:00:00:00:XX')
         _assert('00:00:00:00:00')
-        _assert('AA:BB:cc:dd:ee:ff')
+        _assert('aa_bb_cc_dd_ee_ff')
 
     def test_mac_patch_to_ip_to_network_with_mac_in_use(self):
         """Test that it is not allowed to patch an Ipaddress with a new ipaddress

--- a/mreg/utils.py
+++ b/mreg/utils.py
@@ -119,3 +119,14 @@ def get_network_from_zonename(name):
         for i in it:
             net += "%s%s%s%s:" % (i, next(it, '0'), next(it, '0'), next(it, '0'))
         return ipaddress.ip_network("{}:/{}".format(net, netmask))
+
+# Taken from mreg_cli.util.format_mac.
+def normalize_mac(mac: str) -> str:
+    """
+    Create a strict 'aa:bb:cc:11:22:33' MAC address.
+    Replaces any other delimiters with a colon and turns it into all lower
+    case.
+    """
+    mac = re.sub('[.:-]', '', mac).lower()
+    return ":".join(["%s" % (mac[i:i+2]) for i in range(0, 12, 2)])
+

--- a/mreg/validators.py
+++ b/mreg/validators.py
@@ -122,6 +122,12 @@ def validate_mac_address(address):
                                message="Must be on form: aa:bb:cc:00:11:22")
     validator(address)
 
+def validate_normalizeable_mac_address(address):
+    """Validates that the mac address can be normalized."""
+    adr_regex = "^([a-fA-F0-9]{2}[:.-]?){5}[a-fA-F0-9]{2}$"
+    validator = RegexValidator(adr_regex,
+                               message="Invalid MAC address.")
+    validator(address)
 
 def validate_loc(location):
     """Validates that the loc input is on a valid form."""


### PR DESCRIPTION
Allow MAC address to be specified using `:.-` as optional separators, and also allow uppercase letters.

Note that this will allow MACs such as `AA:BB.cc-ddeeff` and normalize it to `aa:bb:cc:dd:ee:ff`.  Not sure if that is too lenient.

Fixes #394.