### PR TITLE
Change requirements for mac address uniqueness and fix bugs

### DIFF
--- a/mreg/api/v1/serializers.py
+++ b/mreg/api/v1/serializers.py
@@ -95,9 +95,7 @@ class IpaddressSerializer(ValidationMixin, serializers.ModelSerializer):
             # by multiple IP addresses, although normally it would never be more than 1.
             inuse_set = qs.filter(macaddress=mac)
             if inuse_set.exists():
-                ips = []
-                for inuse_ip in inuse_set:
-                    ips.append("{}".format(inuse_ip.ipaddress))
+                ips = inuse_set.values_list('ipaddress', flat=True)
                 msg = "macaddress already in use by: " + ", ".join(ips)
                 raise ValidationError409(msg)
 

--- a/mreg/api/v1/serializers.py
+++ b/mreg/api/v1/serializers.py
@@ -134,9 +134,9 @@ class IpaddressSerializer(ValidationMixin, serializers.ModelSerializer):
                 if ipversion != network.network.version:
                     continue
                 qs = network._used_ipaddresses()
-                # Validate the MAC unless it belonged to the old IP.
-                if self.instance and not self.instance in qs:
-                    _raise_if_mac_found(qs, mac)
+            if self.instance:
+                qs = qs.exclude(id=self.instance.id)
+            _raise_if_mac_found(qs, mac)
         return data
 
 


### PR DESCRIPTION
While investigating [RT #4088062](https://rt.uio.no/Ticket/Display.html?id=4088062), I found a couple of bugs.
I also suggest removing the requirement that mac addresses should be unique across VLANs.
See the commits for details.

Btw, to solve the RT issue, it looks like we may also need to make changes and/or fix bugs in mreg-cli.