### PR TITLE
Fix a bug/security hole in the hostpolicy API

### DIFF
--- a/hostpolicy/api/permissions.py
+++ b/hostpolicy/api/permissions.py
@@ -37,6 +37,9 @@ class IsSuperOrHostPolicyAdminOrReadOnly(IsAuthenticated):
 
         # Find out which labels are attached to this role
         role_labels = HostPolicyRole.objects.filter(name=view.kwargs['name']).values_list('labels__name',flat=True)
+        if not any(role_labels):
+            # if the role doesn't have any labels, there's no possibility of access at this point
+            return False
 
         # Find all the NetGroupRegexPermission objects that correspond with
         # the ipaddress, hostname, and the groups that the user is a member of

--- a/hostpolicy/api/v1/tests.py
+++ b/hostpolicy/api/v1/tests.py
@@ -278,6 +278,19 @@ class HostPolicyWithNetGroupRegexPermission(MregAPITestCase):
         self.role.labels.clear()
         self.assert_post_and_403(url, post_data)
 
+    def test_add_host_if_there_are_no_labels(self):
+        # If the role has no label, the user shouldn't be permitted to add the host to it
+        self.role.labels.remove(self.safelabel)
+        post_data = { 'name': self.host.name }
+        url = self.basepath + self.role.name + '/hosts/'
+        self.assert_post_and_403(url, post_data)
+        # Also try this if the permission doesn't have any labels either
+        self.perm.labels.remove(self.safelabel)
+        self.assert_post_and_403(url, post_data)
+        # Finally, try a case where the role has a label but the permission doesn't have it
+        self.role.labels.add(self.safelabel)
+        self.assert_post_and_403(url, post_data)
+
     def test_add_host_if_user_not_in_group(self):
         self.user.groups.clear()
         post_data = { 'name': self.host.name }


### PR DESCRIPTION
A non-privileged user with network-group-regex permission to a host can add any roles to the host as long as the role does not have any labels.