### PR TITLE
New feature: A special LDAP group allows members to create wildcard DNS records

### DIFF
--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -207,3 +207,4 @@ if TESTING:
     GROUPADMINUSER_GROUP = "default-groupadmin-group"
     NETWORK_ADMIN_GROUP = "default-networkadmin-group"
     HOSTPOLICYADMIN_GROUP = "default-hostpolicyadmin-group"
+    DNS_WILDCARD_GROUP = "default-dns-wildcard-group"


### PR DESCRIPTION
This is a way to delegate creation of wildcard DNS records to non-super-users. Group membership in that LDAP group does not give any other additional forms of access.
Background: Some people on UiO need this to fully automate OpenShift cluster generation with Terraform.