### PR TITLE
Build Docker image using GitHub actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,41 @@
+name: mreg-docker
+on: [push]
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Guix cache
+        uses: actions/cache@v2
+        with:
+          # Note: /gnu/store may exceed the limit of 5GiB, so don't
+          # cache it.  TODO: Selective caching with 'guix archive'?
+          path: |
+            ~/.cache/guix
+          key: guix-cache-${{ github.sha }}
+          restore-keys: |
+            guix-cache-
+      - name: Read channels.scm
+        run: |
+          echo "CHANNELS<<EOF" >> $GITHUB_ENV
+          cat ci/channels.scm >> $GITHUB_ENV
+          echo EOF >> $GITHUB_ENV
+      - name: Install Guix
+        uses: PromyLOPH/guix-install-action@v1
+        with:
+          channels: "${{ env.CHANNELS }}"
+      - name: Build mreg
+        run: guix build --fallback -m ./ci/manifest.scm
+      - name: Pack Docker image
+        run: >
+          guix pack --fallback -f docker --save-provenance --root=mreg-docker.tar.gz
+          -S /bin=bin -S /app=app -S /etc/profile=etc/profile
+          --entry-point=bin/mreg-wrapper
+          -m ./ci/manifest.scm
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: mreg-docker.tar.gz
+          path: mreg-docker.tar.gz

--- a/README.md
+++ b/README.md
@@ -14,6 +14,37 @@ from `requirements.txt`. We use pip.
 
 ### Installing
 
+#### Using a pre-made Docker image.
+
+Pre-built Docker images are available to download from https://github.com/unioslo/mreg/actions/workflows/docker-image.yml.
+
+To use, make the image available to Docker with:
+
+```
+docker load < mreg-docker.tar.gz
+```
+
+It is expected that you mount a custom "mregsite" directory on /app/mregsite:
+
+```
+docker run \
+  --mount type=bind,source=$HOME/customsettings,destination=/app/mregsite,readonly \
+  mreg-wrapper-mreg-python-wrapper:latest
+```
+
+To access application logs outside the container, also mount `/app/logs`.
+
+The Docker image can be reproduced locally by installing [GNU Guix](https://guix.gnu.org) and running:
+
+```
+guix time-machine -C ci/channels.scm -- pack -f docker \
+  -S /bin=bin -S /app=app -S /etc/profile=etc/profile \
+  --entry-point=bin/mreg-wrapper \
+  -m ci/manifest.scm
+```
+
+#### Manually
+
 A step by step series of examples that tell you how to get a development env running
 
 When you've got your copy of the mreg directory, setup you virtual environment.
@@ -91,6 +122,7 @@ DATABASES = {
 * **Nils Hiorth**
 * **Nicolay Mohebi**
 * **Magnus Hirth**
+* **Marius Bakke**
 
 
 ## License

--- a/ci/channels.scm
+++ b/ci/channels.scm
@@ -1,0 +1,10 @@
+(cons (channel
+       (name 'uio)
+       (url "https://github.com/mbakke/guix-uio")
+       (branch "master")
+       (introduction
+        (make-channel-introduction
+         "e346c14b72066b6347a3667d23d792ae664c0447"
+         (openpgp-fingerprint
+          "4D4E 49EE DF36 DA31 0D9D  7734 E871 8BA5 9114 1077"))))
+      %default-channels)

--- a/ci/manifest.scm
+++ b/ci/manifest.scm
@@ -1,0 +1,68 @@
+(use-modules (guix packages)
+             (guix git)
+             (guix gexp)
+             (guix utils)
+             (gnu packages bash)
+             (gnu packages python)
+             (gnu packages python-web)
+             (uio packages mreg))
+
+;; Use the HEAD of the local checkout unless running on the CI.
+(define %commit (getenv "GITHUB_SHA"))
+(define %uri (if %commit
+                 (string-append (getenv "GITHUB_SERVER_URL") "/"
+                                (getenv "GITHUB_REPOSITORY"))
+                 (dirname (dirname (current-filename)))))
+
+(define mreg/dev
+  (package
+    (inherit mreg)
+    (version (string-append "0.0+" (if %commit (string-take %commit 7) "dev")))
+    (source (git-checkout (url %uri) (commit %commit)))))
+
+;; Script to run migrations and start a gunicorn server, used as the
+;; "entry point" in the Docker container.
+;; Note: To use custom site settings, bind a customized "mregsite"
+;; directory to /app/mregsite, like so:
+;;  --mount type=bind,source=$HOME/localsettings,destination=/app/mregsite
+(define* (mreg-wrapper mreg #:optional (args '()))
+  (let ((gunicorn (car (assoc-ref (package-propagated-inputs mreg)
+                                  "gunicorn"))))
+    (with-imported-modules '((guix build utils))
+      (computed-file
+       "mreg-wrapper"
+       #~(begin
+           (use-modules (guix build utils)
+                        (ice-9 format))
+           (let* ((bash #$(file-append bash-minimal "/bin/bash"))
+                  (gunicorn #$(file-append gunicorn "/bin/gunicorn"))
+                  (wrapper (string-append #$output "/bin/mreg-wrapper"))
+                  (mreg #$(file-append mreg "/lib/python"
+                                       (version-major+minor (package-version python))
+                                       "/site-packages/mreg")))
+             (mkdir-p (string-append #$output "/bin"))
+             (copy-recursively mreg (string-append #$output "/app"))
+             (call-with-output-file wrapper
+               (lambda (port)
+                 (format port "#!~a
+export PYTHONPATH=\"/app:$PYTHONPATH\"
+cd /app
+python manage.py migrate --noinput
+exec ~a ~a
+"
+                         bash gunicorn (string-join '#$args " "))))
+             (chmod wrapper #o555)))))))
+
+(define %entry-point
+  (mreg-wrapper
+   mreg/dev
+   '("--workers" "3" "mregsite.wsgi")))
+
+(manifest
+ (append (list (manifest-entry
+                 (version "0")
+                 (name "mreg-wrapper")
+                 (item %entry-point)))
+         (manifest-entries
+          (packages->manifest
+           (list mreg/dev python-wrapper)))))


### PR DESCRIPTION
This PR adds a GitHub action that builds a "production-ready" Docker image of mreg.

Rudimentary usage instructions are provided in the README.

The image is built with [GNU Guix](https://guix.gnu.org/) for transparency and reproducibility.  Guix is a package manager that works on any Linux system, and users do not need root privileges to build/install things.

As a side effect, the tests now run against the latest packages in Guix in addition to the current Travis setup.