### PR TITLE
When reserved adresses are in use, unused_count will subtract them twice

### DIFF
--- a/mreg/api/v1/tests/test_networks.py
+++ b/mreg/api/v1/tests/test_networks.py
@@ -525,6 +525,9 @@ class NetworkExcludedRanges(MregAPITestCase):
     def test_count_unused_ips(self):
         """Test that excluded ipaddresses are exempted from the unused count"""
         self.test_create()
+        # Create a host that uses one of the reserved addresses. (Should not be counted twice)
+        host1 = Host.objects.create(name='host1.example.org')
+        Ipaddress.objects.create(host=host1, ipaddress='10.0.0.255')
         ret = self.assert_get(f'/api/v1/networks/{self.network4}/unused_count').json()
         # /24 - net/broadcast - reserved - [10, 200] - 201
         # 256 - 2             - 3        - 191       - 1   = 59

--- a/mreg/api/v1/tests/test_networks.py
+++ b/mreg/api/v1/tests/test_networks.py
@@ -527,7 +527,7 @@ class NetworkExcludedRanges(MregAPITestCase):
         self.test_create()
         # Create a host that uses one of the reserved addresses. (Should not be counted twice)
         host1 = Host.objects.create(name='host1.example.org')
-        Ipaddress.objects.create(host=host1, ipaddress='10.0.0.255')
+        Ipaddress.objects.create(host=host1, ipaddress='10.0.0.2')
         ret = self.assert_get(f'/api/v1/networks/{self.network4}/unused_count').json()
         # /24 - net/broadcast - reserved - [10, 200] - 201
         # 256 - 2             - 3        - 191       - 1   = 59

--- a/mreg/models.py
+++ b/mreg/models.py
@@ -609,13 +609,9 @@ class Network(BaseModel):
         # subtract excluded ranges
         for i in self.excluded_ranges.all():
             result -= i.num_addresses()
-        # subtract used addresses
-        used = self.used_addresses
-        result -= len(used)
-        # subtract reserved addresses that aren't used
-        for r in self.get_reserved_ipaddresses():
-            if r not in used:
-                result-=1
+        # subtract used and reserved addresses
+        used_or_reserved = self.used_addresses | self.get_reserved_ipaddresses()
+        result -= len(used_or_reserved)
         return result
 
     def get_first_unused(self):

--- a/mreg/models.py
+++ b/mreg/models.py
@@ -609,10 +609,13 @@ class Network(BaseModel):
         # subtract excluded ranges
         for i in self.excluded_ranges.all():
             result -= i.num_addresses()
-        # subtract reserved addresses
-        result -= len(self.get_reserved_ipaddresses())
         # subtract used addresses
-        result -= len(self.used_addresses)
+        used = self.used_addresses
+        result -= len(used)
+        # subtract reserved addresses that aren't used
+        for r in self.get_reserved_ipaddresses():
+            if r not in used:
+                result-=1
         return result
 
     def get_first_unused(self):


### PR DESCRIPTION
Fixes #440.