### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: mreg-docker
+name: Docker
 on:
   push:
     branches: master

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It is expected that you mount a custom "mregsite" directory on /app/mregsite:
 ```
 docker run \
   --mount type=bind,source=$HOME/customsettings,destination=/app/mregsite,readonly \
-  mreg-wrapper-mreg-python-wrapper:latest
+  mreg-wrapper-mreg-python-wrapper:latest --workers=4 --bind=0.0.0.0
 ```
 
 To access application logs outside the container, also mount `/app/logs`.

--- a/ci/manifest.scm
+++ b/ci/manifest.scm
@@ -55,9 +55,7 @@ exec ~a ~a $@
              (chmod wrapper #o555)))))))
 
 (define %entry-point
-  (mreg-wrapper
-   mreg/dev
-   '("--bind=0.0.0.0" "--workers" "3" "mregsite.wsgi")))
+  (mreg-wrapper mreg/dev '("mregsite.wsgi")))
 
 (manifest
  (append (list (manifest-entry

--- a/ci/manifest.scm
+++ b/ci/manifest.scm
@@ -49,7 +49,7 @@ export PYTHONPATH=\"/app:$PYTHONPATH\"
 cd /app
 python manage.py migrate --noinput
 python manage.py delete_all_tokens
-exec ~a ~a
+exec ~a ~a $@
 "
                          bash gunicorn (string-join '#$args " "))))
              (chmod wrapper #o555)))))))

--- a/ci/manifest.scm
+++ b/ci/manifest.scm
@@ -46,7 +46,6 @@
 export PYTHONPATH=\"/app:$PYTHONPATH\"
 cd /app
 python manage.py migrate --noinput
-python manage.py delete_all_tokens
 exec ~a $@ mregsite.wsgi
 "
                        bash gunicorn)))

--- a/ci/manifest.scm
+++ b/ci/manifest.scm
@@ -25,7 +25,7 @@
 ;; Note: To use custom site settings, bind a customized "mregsite"
 ;; directory to /app/mregsite, like so:
 ;;  --mount type=bind,source=$HOME/localsettings,destination=/app/mregsite
-(define* (mreg-wrapper mreg #:optional (args '()))
+(define (mreg-wrapper mreg)
   (with-imported-modules '((guix build utils))
     (computed-file
      "mreg-wrapper"
@@ -47,19 +47,16 @@ export PYTHONPATH=\"/app:$PYTHONPATH\"
 cd /app
 python manage.py migrate --noinput
 python manage.py delete_all_tokens
-exec ~a ~a $@
+exec ~a $@ mregsite.wsgi
 "
-                       bash gunicorn (string-join '#$args " "))))
+                       bash gunicorn)))
            (chmod wrapper #o555))))))
-
-(define %entry-point
-  (mreg-wrapper mreg/dev '("mregsite.wsgi")))
 
 (manifest
  (append (list (manifest-entry
                  (version "0")
                  (name "mreg-wrapper")
-                 (item %entry-point)))
+                 (item (mreg-wrapper mreg/dev))))
          (manifest-entries
           (packages->manifest
            (list mreg/dev python-wrapper)))))


### PR DESCRIPTION
Various improvements to the CI code.

* `docker run mreg --foo --bar` will now pass along `--foo` and `--bar` to gunicorn.
* Running `guix [...] -m ci/manifest.scm` locally now uses the actual `HEAD` commit instead of `master`.
* Small simplifications.