### PR TITLE
Add CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @oyvindkolbu @oyvindhagberg @mbakke @ponas
+/ci/ @mbakke @oyvindhagberg


### PR DESCRIPTION
Manually specifying reviewers on pull requests is tedious.  This ties us further into the GitHub ecosystem by introducing a [CODEOWNERS](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) file that automatically adds reviewers for select parts of the repository.

@oyvindhagberg and @mbakke are @unioslo/dia representatives, and I hope @oyvindkolbu accepts the valued community contributor position :-)

I added @ponas too; you don't seem to have any commits yet, but often have useful feedback.  Let me know if you'd rather lurk in the shadows.

Are there others who would like to get notice about mreg pull requests?  CC @safeaim @paalbra