### PR TITLE
CI: Run tests on pull requests only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 
 name: CI
 jobs:


### PR DESCRIPTION
Since we require all commits on `master` to go through a pull request, there is little use in running the tests again when the PR gets merged.