### PR TITLE
Run CI tests on push events, after all

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,9 @@
-on: [pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'ci/**'
+
+  pull_request:
 
 name: CI
 jobs:
@@ -67,6 +72,7 @@ jobs:
           path: .coverage
 
   coveralls:
+    if: ${{ github.event_name == 'pull_request' || github.repository == 'unioslo/mreg' }}
     name: Coveralls
     needs: test
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This is a revert of 136eeb5bffa5fbffc65fcb918b171898c1a7be72 / #448 which inadvertently disabled both Coveralls tracking as well as CI notifications on forks/other branches.

Sorry for the noise.