### PR TITLE
Avoid delete/create race by only deleting tokens which are expired

### DIFF
--- a/mreg/authentication.py
+++ b/mreg/authentication.py
@@ -1,6 +1,3 @@
-from datetime import timedelta
-
-from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 
@@ -8,9 +5,6 @@ from rest_framework import exceptions
 from rest_framework.authentication import TokenAuthentication
 
 from mreg.models import ExpiringToken
-
-EXPIRE_HOURS = getattr(settings, 'REST_FRAMEWORK_TOKEN_EXPIRE_HOURS', 8)
-
 
 class ExpiringTokenAuthentication(TokenAuthentication):
 
@@ -27,7 +21,7 @@ class ExpiringTokenAuthentication(TokenAuthentication):
         if not token.user.is_active:
             raise exceptions.AuthenticationFailed('User inactive or deleted')
 
-        if token.last_used < timezone.now() - timedelta(hours=EXPIRE_HOURS):
+        if token.is_expired:
             raise exceptions.AuthenticationFailed('Token has expired')
 
         # Save the token to update the last_used field.

--- a/mreg/models.py
+++ b/mreg/models.py
@@ -4,6 +4,7 @@ from collections import defaultdict, namedtuple
 from datetime import timedelta
 from functools import reduce
 
+from django.conf import settings
 import django.contrib.postgres.fields as pgfields
 from django.contrib.auth.models import Group
 from django.db import DatabaseError, models, transaction
@@ -835,3 +836,8 @@ class BACnetID(models.Model):
 
 class ExpiringToken(Token):
     last_used = models.DateTimeField(auto_now=True)
+
+    @property
+    def is_expired(self):
+        EXPIRE_HOURS = getattr(settings, 'REST_FRAMEWORK_TOKEN_EXPIRE_HOURS', 8)
+        return self.last_used < timezone.now() - timedelta(hours=EXPIRE_HOURS)


### PR DESCRIPTION
Check is the token is expired before deleting them. Better approach is to e.g. use django-rest-knox to give each
session an unique token.

Resolves #454 