### PR TITLE
requirements: Turn uritemplate and pyyaml into runtime dependencies.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,3 @@
 mock
 coverage
 coveralls
-uritemplate
-pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ gunicorn==20.1.0
 idna==2.10
 psycopg2-binary==2.8.6
 sentry-sdk==0.17.3
+# For OpenAPI schema generation.
+uritemplate
+pyyaml


### PR DESCRIPTION
...so that OpenAPI schema generation works for users running in a venv.