### PR TITLE
Update dependencies

### DIFF
--- a/ci/manifest.scm
+++ b/ci/manifest.scm
@@ -61,7 +61,7 @@
 export PYTHONPATH=\"/app:$PYTHONPATH\"
 cd /app
 python manage.py migrate --noinput
-exec ~a $GUNICORN_ARGS $@ mregsite.wsgi
+exec ~a $@ mregsite.wsgi
 "
                        bash gunicorn)))
            (chmod wrapper #o555))))))

--- a/mreg/api/v1/tests/tests.py
+++ b/mreg/api/v1/tests/tests.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from operator import itemgetter
 from unittest import skip
 
-import mock
+import unittest.mock as mock
 
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
-mock
 coverage
 coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-Django==3.2.5
-djangorestframework==3.12.4
-django-auth-ldap==2.4.0
+Django==3.2.11
+djangorestframework==3.13.1
+django-auth-ldap==4.0.0
 django-logging-json==1.15
-django-netfields==1.2.2
+django-netfields==1.2.4
 django-url-filter==0.3.15
 gunicorn==20.1.0
 idna==2.10
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.3
 sentry-sdk==0.17.3
 # For OpenAPI schema generation.
 uritemplate


### PR DESCRIPTION
Some minor dependency updates, preparing for Django 4.0.

(mreg works fine with Django 4, but the current version of django-url-filter currrently does not)