### PR TITLE
ci: Update channel URL.

### DIFF
--- a/ci/channels.scm
+++ b/ci/channels.scm
@@ -1,6 +1,6 @@
 (cons (channel
        (name 'uio)
-       (url "https://github.com/mbakke/guix-uio")
+       (url "https://github.com/unioslo/guix-uio")
        (branch "master")
        (introduction
         (make-channel-introduction


### PR DESCRIPTION
The `guix-uio` repository was moved to https://github.com/unioslo/guix-uio a while back.