### PR TITLE
CI: Run 'apt-get update' before installing dependencies.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Needed to build the native python-ldap extension.
+          sudo apt-get update
           sudo apt-get -y install libsasl2-dev libldap2-dev
           pip install -r requirements.txt
           pip install -r requirements-dev.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ on:
   push:
     paths-ignore:
       - 'ci/**'
+      - 'README.md'
 
   pull_request:
 


### PR DESCRIPTION
The [Actions documentation](https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners) recommends running `apt-get update` before using `apt`.

This should solve the error in #468.

While at it, ignore CI on README changes.