### PR TITLE
Add an option to exclude private IP addresses from zone files

### DIFF
--- a/mreg/api/v1/views_zones.py
+++ b/mreg/api/v1/views_zones.py
@@ -391,7 +391,11 @@ def zone_file_detail(request, *args, **kwargs):
     except (ForwardZone.DoesNotExist, ReverseZone.DoesNotExist):
         raise Http404
 
+    excludePrivateAddresses:bool = False
+    if 'excludePrivate' in request.GET and request.GET['excludePrivate'].lower() in ['true','yes','t','y','1']:
+        excludePrivateAddresses = True
+
     # XXX: a force argument to force serialno update?
     zone.update_serialno()
-    zonefile = ZoneFile(zone)
+    zonefile = ZoneFile(zone,excludePrivateAddresses)
     return Response(zonefile.generate())

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@ django-logging-json==1.15
 django-netfields==1.2.4
 django-url-filter==0.3.15
 gunicorn==20.1.0
-idna==2.10
-psycopg2-binary==2.9.3
-pika==1.2.0
-sentry-sdk==0.17.3
+idna==3.4
+psycopg2-binary==2.9.5
+pika==1.3.1
+sentry-sdk==1.15.0
 # For OpenAPI schema generation.
 uritemplate
 pyyaml


### PR DESCRIPTION
This PR adds a query parameter to the zonefile API endpoint that causes mreg to exclude all IP addresses in private address spaces (see [RFC1918](https://www.rfc-editor.org/rfc/rfc1918#section-3)) from the exported zone file.
In short, the address ranges are:
- 10.0.0.0/8
- 172.16.0.0/12
- 192.168.0.0/16

Also, the PR updates requirements.txt with newer versions of some libraries.

The reason behind this is that [Services for sensitive data (TSD)](https://www.uio.no/english/services/it/research/sensitive-data/) are using mreg to create zone files for their DNS server, and they are using private IPv4 addresses internally. They want their DNS server to respond differently depending on whether the request comes from within their own network or from outside.