### PR TITLE
Add a new workflow that builds with a Dockerfile

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,12 +1,77 @@
 name: Container image
-
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - master
+  # Run every week to get updated dependencies.
+  schedule:
+    - cron: '40 08 * * 1'
 
 jobs:
-  hello_world:
+  build:
+    name: Build
     runs-on: ubuntu-latest
-
     steps:
-    - name: Hello World step
-      run: echo "hello world"
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Docker build
+      run: docker build -t mreg .
+    - name: Save image
+      run: docker save mreg | gzip > mreg.tgz
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: mreg
+        path: mreg.tgz
+
+  test:
+    name: Test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Start PostgreSQL
+      run: |
+        docker network create mreg
+        docker run --rm --network mreg -h postgres --name postgres -e POSTGRES_PASSWORD=mreg -e POSTGRES_USER=mreg --detach postgres
+        sleep 3s
+        docker exec postgres psql -U mreg -h localhost -c 'CREATE EXTENSION IF NOT EXISTS citext;' -d template1
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Download artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: mreg
+    - name: Load image
+      run: docker load --input mreg.tgz
+    - name: Run tests
+      run: |
+        docker run --rm -t --network mreg --entrypoint /app/entrypoint-test.sh \
+        --mount type=bind,source=${{github.workspace}}/mregsite,target=/app/mregsite,ro=true \
+        --mount type=tmpfs,target=/app/logs \
+        -e MREG_DB_HOST=postgres -e MREG_DB_PASSWORD=mreg -e MREG_DB_USER=mreg \
+        mreg
+
+  publish:
+    name: Publish
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: mreg
+    - name: Load image
+      run: docker load --input mreg.tgz
+    - name: Log in to registry
+      run: >
+        echo "${{ secrets.GITHUB_TOKEN }}"
+        | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+    - name: Push image
+      run: |
+        IMAGE_ID=ghcr.io/${{ github.repository_owner }}/mreg
+        TAG_NAME=latest
+        docker tag mreg:latest $IMAGE_ID:$TAG_NAME
+        docker push $IMAGE_ID:$TAG_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# build stage
+FROM python:3.10-alpine as builder
+WORKDIR /usr/src/mreg
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+RUN apk update
+RUN apk add --virtual build-deps gcc python3-dev openldap-dev musl-dev
+RUN pip install --upgrade pip
+COPY requirements*.txt ./
+RUN pip wheel --no-cache-dir --wheel-dir /usr/src/mreg/wheels -r requirements.txt
+
+# final stage
+FROM alpine:3.17
+EXPOSE 8000
+
+COPY requirements*.txt entrypoint* manage.py /app/
+COPY mreg /app/mreg/
+COPY hostpolicy /app/hostpolicy/
+COPY --from=builder /usr/src/mreg/wheels /wheels
+RUN apk update && apk upgrade \
+    && apk add python3 py3-pip libldap vim findutils \
+    && pip install --upgrade pip \
+    && pip install --no-cache /wheels/*
+RUN chmod a+x /app/entrypoint*
+
+CMD /app/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mreg [![Build Status](https://github.com/unioslo/mreg/actions/workflows/test.yml/badge.svg)](https://github.com/unioslo/mreg/actions/workflows/test.yml) [![Docker Status](https://github.com/unioslo/mreg/actions/workflows/docker-image.yml/badge.svg)](https://github.com/unioslo/mreg/actions/workflows/docker-image.yml) [![Coverage Status](https://coveralls.io/repos/github/unioslo/mreg/badge.svg?branch=master)](https://coveralls.io/github/unioslo/mreg?branch=master)
+# mreg [![Build Status](https://github.com/unioslo/mreg/actions/workflows/test.yml/badge.svg)](https://github.com/unioslo/mreg/actions/workflows/test.yml) [![Container Status](https://github.com/unioslo/mreg/actions/workflows/container-image.yml/badge.svg)](https://github.com/unioslo/mreg/actions/workflows/container-image.yml) [![Coverage Status](https://coveralls.io/repos/github/unioslo/mreg/badge.svg?branch=master)](https://coveralls.io/github/unioslo/mreg?branch=master)
 mreg is an API (intended to be as RESTful as possible) for managing DNS.
 An associated project for a command line interface using the mreg API is available at:
 [mreg-cli](https://github.com/usit-gd/mreg-cli)

--- a/entrypoint-test.sh
+++ b/entrypoint-test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+cd /app
+./manage.py test --noinput --failfast

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+cd /app
+./manage.py migrate
+#./manage.py runserver 0.0.0.0:8000
+
+# pass signals on to the gunicorn process
+function sigterm()
+{
+	echo "Received SIGTERM"
+	kill -term `cat /var/run/gunicorn.pid`
+}
+trap sigterm SIGTERM
+
+# doing it this way to be able to forward signals
+/usr/bin/gunicorn --workers=3 --bind=0.0.0.0 mregsite.wsgi --pid /var/run/gunicorn.pid &
+wait $!


### PR DESCRIPTION
This PR adds a new workflow that does the following:
- Builds a container image using a Dockerfile
- Tests the image by starting a container and running `manage.py test` inside it
- Publishes the image to GitHub Packages

The badge in the `README.md` file is also updated to reflect the build status of the new workflow.
The workflow aims to replace the one found in `docker-image.yml`.