### PR TITLE
Fewer dependencies for the container image

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -31,13 +31,22 @@ jobs:
     name: Test
     needs: build
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: mreg
+          POSTGRES_PASSWORD: mreg
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd "pg_isready --username=mreg"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Map the containerized port to localhost.
+          - 5432:5432
     steps:
-    - name: Start PostgreSQL
-      run: |
-        docker network create mreg
-        docker run --rm --network mreg -h postgres --name postgres -e POSTGRES_PASSWORD=mreg -e POSTGRES_USER=mreg --detach postgres
-        sleep 3s
-        docker exec postgres psql -U mreg -h localhost -c 'CREATE EXTENSION IF NOT EXISTS citext;' -d template1
     - name: Checkout
       uses: actions/checkout@v3
     - name: Download artifact
@@ -48,10 +57,8 @@ jobs:
       run: docker load --input mreg.tgz
     - name: Run tests
       run: |
-        docker run --rm -t --network mreg --entrypoint /app/entrypoint-test.sh \
-        --mount type=bind,source=${{github.workspace}}/mregsite,target=/app/mregsite,ro=true \
-        --mount type=tmpfs,target=/app/logs \
-        -e MREG_DB_HOST=postgres -e MREG_DB_PASSWORD=mreg -e MREG_DB_USER=mreg \
+        docker run --rm -t --network host --entrypoint /app/entrypoint-test.sh \
+        -e MREG_DB_HOST=localhost -e MREG_DB_PASSWORD=mreg -e MREG_DB_USER=mreg \
         mreg
 
   publish:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ EXPOSE 8000
 
 COPY requirements*.txt entrypoint* manage.py /app/
 COPY mreg /app/mreg/
+COPY mregsite /app/mregsite/
+RUN --mount=type=tmpfs,target=/app/logs
 COPY hostpolicy /app/hostpolicy/
 COPY --from=builder /usr/src/mreg/wheels /wheels
 RUN apk update && apk upgrade \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ EXPOSE 8000
 COPY requirements*.txt entrypoint* manage.py /app/
 COPY mreg /app/mreg/
 COPY mregsite /app/mregsite/
-RUN --mount=type=tmpfs,target=/app/logs
+RUN  mkdir /app/logs
 COPY hostpolicy /app/hostpolicy/
 COPY --from=builder /usr/src/mreg/wheels /wheels
 RUN apk update && apk upgrade \

--- a/README.md
+++ b/README.md
@@ -5,12 +5,9 @@ An associated project for a command line interface using the mreg API is availab
 
 ## Getting Started
 
-
 ### Prerequisites
 
-Fork the project from github.
-You need a terminal, `python3`, and access to a package manager that can install the necessary requirements
-from `requirements.txt`. We use pip.
+If you want to set up your own PostgreSQL server by installing the necessary packages manually, you might need to install dependencies for setting up the citext extension. On Fedora, the package is called [`postgresql-contrib`](https://packages.fedoraproject.org/pkgs/postgresql/postgresql-contrib/).
 
 ### Installing
 
@@ -46,26 +43,28 @@ For a full example, see `docker-compose.yml`.
 
 #### Manually
 
-A step by step series of examples that tell you how to get a development env running
+##### A step by step series of examples that tell you how to get a development env running:
 
-When you've got your copy of the mreg directory, setup you virtual environment.
+Start by cloning the project from github. You need a terminal, `python3`, and access to a package manager that can install the necessary requirements from `requirements.txt`. We use pip.
+
+When you've got your copy of the mreg directory, setup you virtual environment:
 ```
 > python3 -m venv venv
 > source venv/bin/activate
 ```
-Then install the required packages
+Then install the required packages:
 ```
 > pip install -r requirements.txt
 ```
-Perform database migrations
+Perform database migrations:
 ```
 > python manage.py migrate
 ```
-Load sample data from fixtures into the now migrated database
+Load sample data from fixtures into the now migrated database:
 ```
 > python manage.py loaddata mreg/fixtures/fixtures.json
 ```
-And finally, run the server.
+And finally, run the server:
 ```
 > python manage.py runserver
 ```

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ from `requirements.txt`. We use pip.
 #### Using Docker.
 
 Pre-built Docker images are available from [`ghcr.io/unioslo/mreg`](https://ghcr.io/unioslo/mreg):
-
 ```
 docker pull ghcr.io/unioslo/mreg
+```
+You can also build locally, from the source:
+```
+docker build -t mreg .
 ```
 
 It is expected that you mount a custom "mregsite" directory on /app/mregsite:
@@ -27,19 +30,19 @@ It is expected that you mount a custom "mregsite" directory on /app/mregsite:
 ```
 docker run \
   --mount type=bind,source=$HOME/customsettings,destination=/app/mregsite,readonly \
-  ghcr.io/unioslo/mreg:latest --workers=4 --bind=0.0.0.0
+  ghcr.io/unioslo/mreg:latest
 ```
 
 To access application logs outside the container, also mount `/app/logs`.
 
-The Docker image can be reproduced locally by installing [GNU Guix](https://guix.gnu.org) and running:
+It is also possible to not mount a settings directory, and to supply database login details in environment variables instead, overriding the default values found in `mregsite/settings.py`.
+```
+docker run --network host \
+  -e MREG_DB_HOST=my_postgres_host -e MREG_DB_NAME=mreg -e MREG_DB_USER=mreg -e MREG_DB_PASSWORD=mreg \
+  ghcr.io/unioslo/mreg:latest
+```
 
-```
-guix time-machine -C ci/channels.scm -- pack -f docker \
-  -S /app=app -S /etc/profile=etc/profile \
-  --entry-point=bin/mreg-wrapper \
-  -m ci/manifest.scm
-```
+For a full example, see `docker-compose.yml`.
 
 #### Manually
 
@@ -121,6 +124,9 @@ DATABASES = {
 * **Nicolay Mohebi**
 * **Magnus Hirth**
 * **Marius Bakke**
+* **Safet Amedov**
+* **Tannaz Roshandel**
+* **Terje Kvernes**
 
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
+# THIS DOCKER COMPOSE FILE IS ONLY PROVIDED AS AN EXAMPLE, IT IS NOT SUITABLE FOR PRODUCTION AS IS.
 services:
   postgres:
+    # If you want the data in the database to remain after the container is stopped,
+    # you should mount a directory into /var/lib/postgresql/data, or use a volume. See the documentation:
+    # https://github.com/docker-library/docs/blob/master/postgres/README.md#where-to-store-data
     image: postgres
     environment:
       - POSTGRES_USER=mreg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  postgres:
+    image: postgres
+    environment:
+      - POSTGRES_USER=mreg
+      - POSTGRES_DB=mreg
+      - POSTGRES_PASSWORD=mreg
+    healthcheck:
+       test: ["CMD", "pg_isready", "--username=mreg"]
+       interval: 10s
+       timeout: 5s
+       retries: 5
+       start_period: 5s
+
+  # Uncomment this if you want a RabbitMQ server to send events to. See also MQ config in settings.py
+  # rabbitmq:
+  #   image: rabbitmq
+  #   ports:
+  #     - 5672:5672
+
+  mreg:
+    depends_on:
+      postgres:
+        condition: service_healthy
+      #rabbitmq:
+      #  condition: service_started
+    build: .
+    ports:
+      - 8000:8000
+    environment:
+      - MREG_DB_HOST=postgres
+      - MREG_DB_NAME=mreg
+      - MREG_DB_USER=mreg
+      - MREG_DB_PASSWORD=mreg

--- a/entrypoint-test.sh
+++ b/entrypoint-test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 cd /app
-./manage.py create_citext_extension
+./manage.py create_citext_extension --database template1
 ./manage.py test --noinput --failfast

--- a/entrypoint-test.sh
+++ b/entrypoint-test.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 set -e
 cd /app
+./manage.py create_citext_extension
 ./manage.py test --noinput --failfast

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 cd /app
+./manage.py create_citext_extension
 ./manage.py migrate
 #./manage.py runserver 0.0.0.0:8000
 

--- a/mreg/management/commands/create_citext_extension.py
+++ b/mreg/management/commands/create_citext_extension.py
@@ -1,17 +1,38 @@
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
 from sys import stdout
+from django.conf import settings
+from psycopg2 import connect
 
 class Command(BaseCommand):
 	help = 'Create the CITEXT extension in the database.'
 
-	def handle(self, *args, **kwargs):
+	def add_arguments(self, parser):
+		# optional argument
+		parser.add_argument(
+			'--database',
+			type=str,
+			help='Database name',
+		)
+
+	def handle(self, *args, **options):
 		stdout.write("Attempting to create the CITEXT extension in the database...\n")
 		stdout.flush()
 		try:
-			with connection.cursor() as cursor:
+			con = connection
+			if options['database']:
+				stdout.write(f"Connecting to database {options['database']}\n")
+				stdout.flush()
+				con = connect(host=settings.DATABASES['default']['HOST'],
+					user=settings.DATABASES['default']['USER'],
+					password=settings.DATABASES['default']['PASSWORD'],
+					database=options['database'])
+			with con.cursor() as cursor:
 				cursor.execute("CREATE EXTENSION IF NOT EXISTS citext")
 				stdout.write(cursor.statusmessage+"\n")
 				stdout.flush()
+				con.commit()
 		except Exception as e:
+			stdout.write(e.__str__())
+			stdout.flush()
 			raise CommandError('Failed to create the CITEXT extension in the database.')

--- a/mreg/management/commands/create_citext_extension.py
+++ b/mreg/management/commands/create_citext_extension.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection
+from sys import stdout
+
+class Command(BaseCommand):
+	help = 'Create the CITEXT extension in the database.'
+
+	def handle(self, *args, **kwargs):
+		stdout.write("Attempting to create the CITEXT extension in the database...\n")
+		stdout.flush()
+		try:
+			with connection.cursor() as cursor:
+				cursor.execute("CREATE EXTENSION IF NOT EXISTS citext")
+				stdout.write(cursor.statusmessage+"\n")
+				stdout.flush()
+		except Exception as e:
+			raise CommandError('Failed to create the CITEXT extension in the database.')


### PR DESCRIPTION
This PR does the following:
- The entrypoint in the container image will create the CITEXT extension in the database if needed. Previously, that had to be done before starting the container.
- The container image is built with default mregsite and logs directories, so it can run without these being mounted into it. Previously it would exit unless these were mounted in.
- A docker-compose.yml file is added to the repo.
- The section about Docker in the README file is updated. Also add names of more contributors.
- ~The container-image.yml workflow is modified to trigger on pushes to all branches, but only push the built image to ghcr.io if the branch is master. This way, we get to test that workflow on new code before merging into master.~
*Done in https://github.com/unioslo/mreg/commit/749d0968b034ee982c91ee17d37df3d04e3262c7*