### PR TITLE
Fix a bug in history.py / DjangoJSONModelEncoder

### DIFF
--- a/hostpolicy/api/v1/tests.py
+++ b/hostpolicy/api/v1/tests.py
@@ -99,6 +99,10 @@ class HostPolicyAtomTestCase(HostPolicyRoleTestCase):
         self.object_one, _ = HostPolicyAtom.objects.get_or_create(name='testatom1')
         self.object_two, _ = HostPolicyAtom.objects.get_or_create(name='testatom2')
 
+    def test_create_with_date(self):
+        post_data = {"name": "orange", "description": "Round and orange", "create_date": "2018-07-07"}
+        self.assert_post('/api/v1/hostpolicy/atoms/', post_data)
+
 
 class HostPolicyAdminRights(MregAPITestCase):
     """Test that all of the API for HostPolicy are available for the admin group

--- a/mreg/api/v1/history.py
+++ b/mreg/api/v1/history.py
@@ -11,7 +11,9 @@ from mreg.models import History
 class DjangoJSONModelEncoder(DjangoJSONEncoder):
 
     def default(self, o):
-        return model_to_dict(o)
+        if isinstance(o, Model):
+            return model_to_dict(o)
+        return super().default(o)
 
 
 class HistoryLog:


### PR DESCRIPTION
The bug was introduced in 014e25b6030a05adf9622694539b92a38f71a2b1 when removing what was thought to be unused code paths. Unfortunately, we didn't have a test that covered the particular case where this code path was used.
This commit adds a test and fixes the bug.