### PR TITLE
Log unexpected input to DjangoJSONModelEncoder.

### DIFF
--- a/mreg/api/v1/history.py
+++ b/mreg/api/v1/history.py
@@ -1,5 +1,9 @@
 import json
 
+import datetime
+
+from django_logging import log
+
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Model
@@ -13,6 +17,10 @@ class DjangoJSONModelEncoder(DjangoJSONEncoder):
     def default(self, o):
         if isinstance(o, Model):
             return model_to_dict(o)
+        elif isinstance(o, datetime.date):
+            return super().default(o)
+
+        log.warning("DjangoJSONModelEncoder, unexpected type: '%s'", type(o))
         return super().default(o)
 
 


### PR DESCRIPTION
https://github.com/unioslo/mreg/commit/014e25b6030a05adf9622694539b92a38f71a2b1 removed the calls to `super().default(o)` and thus broke the case where DjangoJSONModelEncoder was fed a datetime.date object.

This was resolved in https://github.com/unioslo/mreg/pull/496, but it would be good to know if there is any other unexpected input coming into the encoder.