### PR TITLE
Multi-python testing via tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,18 @@ exclude = [
     "hostpolicy/migrations/",
     ".tox",
 ]
+
+[project]
+name = "mreg"
+version = "0.0.1"
+
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+    "setuptools >= 46.1.0",
+    "wheel",
+    "toml"
+]
+
+[tool.setuptools]
+py-modules = ["mreg", "mregsite", "hostpolicy"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,29 @@
+[tox]
+minversion = 4.0
+skip_missing_interpreters = true
+toxworkdir = {env:TOX_WORKDIR:.tox}
+envlist =
+    lint
+    coverage
+    python{37,38,39,310,311}
+
+[testenv]
+setenv =
+    DJANGO_SETTINGS_MODULE=mregsite.settings
+    CI=True
+passenv = MREG_*, GITHUB_*
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt
+basepython =
+    python37: python3.7
+    python38: python3.8
+    python39: python3.9
+    python310: python3.10
+    python311: python3.11
+allowlist_externals = coverage
+commands = coverage run manage.py test
+
 [testenv:lint]
 description = Lint the project.
 setenv =
@@ -7,3 +33,38 @@ passenv = MREG_*, GITHUB_*
 skip_install = true
 deps = ruff
 commands = ruff check .
+
+[testenv:coverage]
+description = Perform a coverage run and report the results.
+setenv =
+    DJANGO_SETTINGS_MODULE=mregsite.settings
+    CI=True
+passenv = MREG_*, GITHUB_*
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt
+allowlist_externals = coverage
+commands =
+    coverage run manage.py test
+    coverage report -m
+
+[coverage:report]
+fail_under = 98
+show_missing = true
+exclude_lines =
+    'pragma: no cover'
+    'def __repr__'
+
+[coverage:run]
+omit =
+    manage.py
+    */migrations/*
+    # omit anything in a .local, venv/* directory anywhere
+    */.local/*
+    venv/*
+    env/*
+    */.virtualenvs/*
+    */virtualenv/*
+
+[coverage:html]
+directory = coverage_html_report


### PR DESCRIPTION
  - Supports tox environments for python3.7 to 3.11 (tox -e python37, etc)
  - By default tests all python versison (3.7-3.11)
  - Also provides a pure coverage environment to run and see coverage
    (tox -e coverage)