### PR TITLE
Handle secrets at the login endpoint

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -89,6 +89,10 @@ jobs:
         pip install -e .
     - name: Run the tests
       run: mreg-cli-master/ci/run_testsuite_and_record.sh
+    - name: Upload the log as an artifact
+      uses: actions/upload-artifact@v3
+      with:
+        path: mreg-cli-master/ci/new_testsuite_log.json
 
   publish:
     name: Publish

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -92,6 +92,7 @@ jobs:
     - name: Upload the log as an artifact
       uses: actions/upload-artifact@v3
       with:
+        name: new_testsuite_log.json
         path: mreg-cli-master/ci/new_testsuite_log.json
 
   publish:

--- a/mreg/api/v1/tests/test_logging.py
+++ b/mreg/api/v1/tests/test_logging.py
@@ -263,15 +263,15 @@ class TestLoggingMiddleware(MregAPITestCase):
                 {"username": self.user.username, "password": the_password},
             )
 
-            strings_we_dont_want = [
-                #            self.user.username,
-                the_password,
-                ExpiringToken.objects.get(user=self.user).key,
-            ]
+            the_token = ExpiringToken.objects.get(user=self.user).key
 
-            for log in handler.logs:
-                for s in strings_we_dont_want:
-                    self.assertNotIn(s, log)
+            req = handler.logs[0]
+            res = handler.logs[1]
+
+            self.assertNotIn(the_password, req)
+            self.assertNotIn(the_token, res)
+            self.assertIn("'password': '...'", req)
+            self.assertIn("...", res)
 
         finally:
             logger.removeHandler(handler)

--- a/mreg/api/v1/views_zones.py
+++ b/mreg/api/v1/views_zones.py
@@ -364,7 +364,7 @@ class PlainTextRenderer(renderers.TemplateHTMLRenderer):
 
     def render(self, data, media_type=None, renderer_context=None):
         # Utilize TemplateHTMLRenderer's exception handling
-        if type(data) is dict:
+        if isinstance(data, dict):
             return super().render(data, accepted_media_type=None,
                                   renderer_context=renderer_context)
         return data.encode(self.charset)

--- a/mreg/log_processors.py
+++ b/mreg/log_processors.py
@@ -18,11 +18,11 @@ def _replace_token(token: str) -> str:
 
 def filter_sensitive_data(_: Any, __: Any, event_dict: EventDict) -> EventDict:
     """Filter sensitive data from a structlogs event_dict.
-    
+
     :param _: Unused parameter
     :param __: Unused parameter
     :param event_dict: Dictionary containing event data.
-    
+
     :returns: Event dictionary with sensitive data filtered.
     """
     LOGIN_PATH = "/api/token-auth/"
@@ -30,22 +30,21 @@ def filter_sensitive_data(_: Any, __: Any, event_dict: EventDict) -> EventDict:
     if "model" in event_dict and event_dict["model"] in ["ExpiringToken", "Session"]:
         clean_token = _replace_token(event_dict["_str"])
         event_dict["_str"] = clean_token
-        event_dict["id"] = clean_token        
+        event_dict["id"] = clean_token
 
     is_login_event = (
-        "path" in event_dict 
-        and event_dict["path"] == LOGIN_PATH 
-        and "method" in event_dict 
+        "path" in event_dict
+        and event_dict["path"] == LOGIN_PATH
+        and "method" in event_dict
         and event_dict["method"] == "POST"
     )
-    
+
     if is_login_event:
         content: str = event_dict["content"]
         event: str = event_dict["event"]
 
         if event == "request" and "password" in content:
             event_dict["content"]["password"] = '...'
-        
         elif event == "response" and "token" in content:
             token = content.split('"token":"')[1].split('"')[0]
             event_dict["content"] = content.replace(token, _replace_token(token))

--- a/mreg/log_processors.py
+++ b/mreg/log_processors.py
@@ -28,8 +28,9 @@ def filter_sensitive_data(_: Any, __: Any, event_dict: EventDict) -> EventDict:
     LOGIN_PATH = "/api/token-auth/"
 
     if "model" in event_dict and event_dict["model"] in ["ExpiringToken", "Session"]:
-        event_dict["_str"] = _replace_token(event_dict["_str"])
-        event_dict["id"] = _replace_token(event_dict["id"])
+        clean_token = _replace_token(event_dict["_str"])
+        event_dict["_str"] = clean_token
+        event_dict["id"] = clean_token        
 
     is_login_event = (
         "path" in event_dict 

--- a/mreg/log_processors.py
+++ b/mreg/log_processors.py
@@ -29,7 +29,7 @@ def filter_sensitive_data(_: Any, __: Any, event_dict: EventDict) -> EventDict:
 
     if "model" in event_dict and event_dict["model"] in ["ExpiringToken", "Session"]:
         event_dict["_str"] = _replace_token(event_dict["_str"])
-        event_dict["id"] = _replace_token(event_dict["_str"])
+        event_dict["id"] = _replace_token(event_dict["id"])
 
     is_login_event = (
         "path" in event_dict 


### PR DESCRIPTION
  - Don't log the password for users logging in.
  - In the logging of responses, collapse the token returned for working logins.

(Also fixes a type comparison due to ruff changes.)

Fixes #517