### PR TITLE
Add a permission group that allows members to create names with underscores

### DIFF
--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -10,6 +10,7 @@ NETWORK_ADMIN_GROUP = 'NETWORK_ADMIN_GROUP'
 SUPERUSER_GROUP = 'SUPERUSER_GROUP'
 ADMINUSER_GROUP = 'ADMINUSER_GROUP'
 DNS_WILDCARD_GROUP = 'DNS_WILDCARD_GROUP'
+DNS_UNDERSCORE_GROUP = 'DNS_UNDERSCORE_GROUP'
 
 
 def get_settings_groups(group_setting_name):
@@ -134,9 +135,11 @@ def _deny_superuser_only_names(data=None, name=None, view=None, request=None):
             if 'host' in data:
                 name = data['host'].name
 
-    # Underscore is allowed for non-superuser in SRV records
+    # Underscore is allowed for non-superuser in SRV records,
+    # and for members of <DNS_UNDERSCORE_GROUP> in all records.
     if '_' in name and not isinstance(view, (mreg.api.v1.views.SrvDetail,
-                                             mreg.api.v1.views.SrvList)):
+                                             mreg.api.v1.views.SrvList)) \
+                   and not request_in_settings_group(request, DNS_UNDERSCORE_GROUP):
         return True
 
     # Except for super-users, only members of the DNS wildcard group can create wildcard records.

--- a/mreg/api/v1/tests/test_host_permissions.py
+++ b/mreg/api/v1/tests/test_host_permissions.py
@@ -282,9 +282,24 @@ class Txts(HostBasePermissions):
 
 
 class Underscore(MregAPITestCase):
-    """Test that only superusers can create entries with an underscore."""
 
+    """Test that superusers can create entries with an underscore, but regular users can't."""
     def test_can_create_hostname_with_prefix_underscore(self):
+        data1 = {'name': '_host1.example.org', 'ipaddress': '10.0.0.1'}
+        data2 = {'name': 'host2._sub.example.org', 'ipaddress': '10.0.0.2'}
+        superuser_client = self.client
+        self.client = self.get_token_client(superuser=False)
+        self.assert_post_and_403('/hosts/', data1)
+        self.assert_post_and_403('/hosts/', data2)
+        self.client = superuser_client
+        self.assert_post('/hosts/', data1)
+        self.assert_post('/hosts/', data2)
+
+    """Members in DNS_UNDERSCORE_GROUP can create entries with an underscore."""
+    def test_special_group_members_create_underscore(self):
+        self.client = self.get_token_client(superuser=False, adminuser=True)
+        self.add_user_to_groups('DNS_UNDERSCORE_GROUP')
+        path = '/api/v1/hosts/'
         data1 = {'name': '_host1.example.org', 'ipaddress': '10.0.0.1'}
         data2 = {'name': 'host2._sub.example.org', 'ipaddress': '10.0.0.2'}
         self.assert_post('/hosts/', data1)

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -329,3 +329,4 @@ if TESTING or "CI" in os.environ:
     NETWORK_ADMIN_GROUP = "default-networkadmin-group"
     HOSTPOLICYADMIN_GROUP = "default-hostpolicyadmin-group"
     DNS_WILDCARD_GROUP = "default-dns-wildcard-group"
+    DNS_UNDERSCORE_GROUP = "default-dns-underscore-group"


### PR DESCRIPTION
This PR adds a new permission group that allows members of that group to use the underscore character in names when creating all types of DNS records.
Regular users are still only allowed to use underscores in SRV records.

### Bakgrunn:

_Utdrag fra epost-tråd mellom Øyvind H. og Mikael D. fredag 27.oktober:_
> _Øyvind_:
>Magnus H. og jeg hadde en samtale hvor vi snakket om problemet med Windows-domenekontrollere som skaper behov for hostnavn med understrek.
>Slik de jobber så trenger de å gjøre endringer i DNS stadig vekk, og de ønsker å kunne bruke mreg til det.
>Vi var innom noen alternative løsninger (f.eks. at de bruker en egen DNS-server og går utenom mreg) men fant egentlig ingen annen god løsning som ville dekket behovene.

> _Mikael_:
>Magnus og jeg hadde også en diskusjon om dette. Som jeg nevnte så er jeg
>tvilende til å åpne for _ (utenom SRV) for "hvermansen" - påtvunget
>force eller ei. Å gi superbruker bare for dette er prinsipielt heller
>ikke riktig løsning. Det er jo ikke veldig mange som vil trenge dette;
>dvs. endre eller lage slike records såpass ofte at man ikke bare kan be
>hostmaster eller tilsvarende hver gang. Så jeg er enig i at en klasse
>til for dette som man kan gi de med behov er en grei løsning. Så må de
>som ønsker denne rollen selvsagt først be hostmaster på sine knær og
>ofre et tilstrekkelig antall Snickers!
