### PR TITLE
Fix build error by bumping base image versions in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM python:3.10-alpine as builder
+FROM python:3.11-alpine as builder
 WORKDIR /usr/src/mreg
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
@@ -11,7 +11,7 @@ COPY requirements*.txt ./
 RUN pip wheel --no-cache-dir --wheel-dir /usr/src/mreg/wheels -r requirements.txt
 
 # final stage
-FROM alpine:3.17
+FROM alpine:3.18
 EXPOSE 8000
 
 COPY requirements*.txt entrypoint* manage.py /app/


### PR DESCRIPTION
Recently, building the container images started to fail: https://github.com/unioslo/mreg/actions/runs/8784288442/job/24102213934

It's hard to know exactly when, because GitHub had disabled the Container Image workflow due to low activity in the repo. Regardless, the issue can be fixed by using newer versions of the base images.
I've done no further investigation (It works, so it's probably ok?)