### PR TITLE
Add Meta endpoints.

### DIFF
--- a/mreg/api/urls.py
+++ b/mreg/api/urls.py
@@ -5,4 +5,6 @@ from . import views
 urlpatterns = [
     path('token-logout/', views.TokenLogout.as_view()),
     path('token-auth/', views.ObtainExpiringAuthToken.as_view()),
+    path('meta/heartbeat', views.MetaHeartbeat.as_view()),
+    path('meta/versions', views.MetaVersions.as_view()),
 ]

--- a/mreg/api/v1/tests/tests.py
+++ b/mreg/api/v1/tests/tests.py
@@ -121,6 +121,9 @@ class MregAPITestCase(APITestCase):
     def assert_get_and_401(self, path, **kwargs):
         return self._assert_get_and_status(path, 401, **kwargs)
 
+    def assert_get_and_403(self, path, **kwargs):
+        return self._assert_get_and_status(path, 403, **kwargs)
+
     def assert_get_and_404(self, path, **kwargs):
         return self._assert_get_and_status(path, 404, **kwargs)
 
@@ -279,6 +282,26 @@ class APITokenAuthenticationTestCase(MregAPITestCase):
         """ Incorrect or missing arguments should still return 400 bad request """
         self.assert_post_and_400("/api/token-auth/", {"who": "someone", "why": "because"})
         self.assert_post_and_400("/api/token-auth/", {})
+
+class APIMetaTestCase(MregAPITestCase):
+    """Test the meta API endpoint."""
+
+    def test_meta_versions_admin_200_ok(self):
+        response = self.assert_get_and_200("/api/meta/versions")
+        for key in ('rest_framework_version', 'django_version', 'python_version'):
+            self.assertTrue(key in response.data)
+            print(key, response.data[key])
+
+    def test_meta_versions_user_403_forbidden(self):
+        self.client = self.get_token_client(superuser=False)
+        self.assert_get_and_403("/api/meta/versions")
+
+    def test_meta_heartbeat_user_200_ok(self):
+        self.client = self.get_token_client(superuser=False)
+        response = self.assert_get("/api/meta/heartbeat")
+        for key in ('uptime', 'start_time'):
+            self.assertTrue(key in response.data)
+            print(key, response.data[key])
 
 
 class APIAutoupdateZonesTestCase(MregAPITestCase):

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -1,28 +1,46 @@
-from rest_framework import status
+import platform
+import time
+from typing import Any, cast
+
+import django
+from rest_framework import __version__ as res_version
+from rest_framework import serializers, status
 from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework import serializers
-from rest_framework.exceptions import AuthenticationFailed
 
+from mreg.api.permissions import IsSuperOrNetworkAdminMember
 from mreg.models.base import ExpiringToken
+
+start_time = int(time.time())
 
 
 class ObtainExpiringAuthToken(ObtainAuthToken):
 
-    def post(self, request, *args, **kwargs):
-        serializer = self.serializer_class(data=request.data,
-                                           context={'request': request})
+    def post(self, request: Request, *args: Any, **kwargs: Any):
+        serializer = self.serializer_class(data=request.data, context={"request": request})
         try:
             serializer.is_valid(raise_exception=True)
         except serializers.ValidationError as err:
-            if 'username' in request.POST and 'password' in request.POST:
+            if (
+                isinstance(request.POST, dict)
+                and "username" in request.POST
+                and "password" in request.POST
+            ):
                 raise AuthenticationFailed()
             else:
                 raise err
 
-        user = serializer.validated_data['user']
+        if (
+            not isinstance(serializer.validated_data, dict)
+            or "user" not in serializer.validated_data
+        ):
+            raise AuthenticationFailed()
+
+        user = cast(str, serializer.validated_data["user"])
 
         token, created = ExpiringToken.objects.get_or_create(user=user)
 
@@ -31,15 +49,41 @@ class ObtainExpiringAuthToken(ObtainAuthToken):
             ExpiringToken.objects.filter(user=user).delete()
             token, _ = ExpiringToken.objects.get_or_create(user=user)
 
-        return Response({'token': token.key})
+        return Response({"token": token.key})
 
 
 class TokenLogout(APIView):
 
-    permission_classes = (IsAuthenticated, )
+    permission_classes = (IsAuthenticated,)
 
-    def post(self, request):
+    def post(self, request: Request):
         # delete the user on logout to clean up the local user database and
         # group memberships. As the user owns the token, it will also be deleted.
         request.user.delete()
         return Response(status=status.HTTP_200_OK)
+
+
+class MetaVersions(APIView):
+
+    permission_classes = (IsSuperOrNetworkAdminMember,)
+
+    def get(self, request: Request):
+        data = {
+            "django_version": django.get_version(),
+            "rest_framework_version": res_version,
+            "python_version": platform.python_version(),
+        }
+        return Response(status=status.HTTP_200_OK, data=data)
+
+
+class MetaHeartbeat(APIView):
+
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request: Request):
+        uptime = int(start_time - time.time())
+        data = {
+            "start_time": start_time,
+            "uptime": uptime,
+        }
+        return Response(status=status.HTTP_200_OK, data=data)


### PR DESCRIPTION
These endpoints are not API specific, they are at the root of the server as `/api/meta/versions` and `/api/meta/heartbeat`.

  - Heartbeat (start time and uptime) is open for anyone authenticated.
  - Versions (python, django, drf) is available to admins.