### PR TITLE
Further filter fixes.

### DIFF
--- a/hostpolicy/api/v1/views.py
+++ b/hostpolicy/api/v1/views.py
@@ -2,7 +2,8 @@ from django.db.models import Prefetch
 from rest_framework import status
 from rest_framework.response import Response
 
-from django_filters import rest_framework as rest_filters
+from django_filters import rest_framework as filters
+from rest_framework import filters as rest_filters
 
 from hostpolicy.api.permissions import IsSuperOrHostPolicyAdminOrReadOnly
 from hostpolicy.models import HostPolicyAtom, HostPolicyRole
@@ -18,39 +19,60 @@ from mreg.api.v1.views_m2m import M2MDetail, M2MList, M2MPermissions
 from mreg.mixins import LowerCaseLookupMixin
 from mreg.models.host import Host
 
+from mreg.api.v1.filters import STRING_OPERATORS, INT_OPERATORS
+
 from . import serializers
 
-# For some reason the name field for filtersets for HostPolicyAtom and HostPolicyRole does
-# not support operators (e.g. __contains, __regex) in the same way as other fields. Yes,
-# the name field is a LowerCaseCharField, but the operators work fine in mreg proper.
-# To resolve this issue, we create custom fields for the filtersets that use the name field.
-
-class HostPolicyAtomFilterSet(rest_filters.FilterSet):
-    name__contains = rest_filters.CharFilter(field_name="name", lookup_expr="contains")
-    name__regex = rest_filters.CharFilter(field_name="name", lookup_expr="regex")
-
+# Note that related lookups don't work at the moment, so we need to do them explicitly.
+class HostPolicyAtomFilterSet(filters.FilterSet):
     class Meta:
         model = HostPolicyAtom
-        fields = "__all__"
+        fields = {
+            "name": STRING_OPERATORS,
+            "create_date": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "description": STRING_OPERATORS,
+            "roles": INT_OPERATORS,
+        }
 
 
-class HostPolicyRoleFilterSet(rest_filters.FilterSet):
-    name__contains = rest_filters.CharFilter(field_name="name", lookup_expr="contains")
-    name__regex = rest_filters.CharFilter(field_name="name", lookup_expr="regex")
+class HostPolicyRoleFilterSet(filters.FilterSet):
+    atoms__name__exact = filters.CharFilter(field_name='atoms__name', lookup_expr='exact')
+
     class Meta:
         model = HostPolicyRole
-        fields = "__all__"
+        fields = {
+            "name": STRING_OPERATORS,
+            "create_date": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "hosts": INT_OPERATORS,
+            "atoms": INT_OPERATORS,
+            "labels": INT_OPERATORS,
+        }
 
 class HostPolicyAtomLogMixin(HistoryLog):
 
     log_resource = 'hostpolicy_atom'
     model = HostPolicyAtom
+    filter_backends = (
+        rest_filters.SearchFilter,
+        filters.DjangoFilterBackend,
+        rest_filters.OrderingFilter,
+    )
+    ordering_fields = "__all__"
+
 
 
 class HostPolicyRoleLogMixin(HistoryLog):
 
     log_resource = 'hostpolicy_role'
     model = HostPolicyRole
+    filter_backends = (
+        rest_filters.SearchFilter,
+        filters.DjangoFilterBackend,
+        rest_filters.OrderingFilter,
+    )
+    ordering_fields = "__all__"
 
 
 class HostPolicyPermissionsListCreateAPIView(M2MPermissions,

--- a/hostpolicy/api/v1/views.py
+++ b/hostpolicy/api/v1/views.py
@@ -37,7 +37,18 @@ class HostPolicyAtomFilterSet(filters.FilterSet):
 
 
 class HostPolicyRoleFilterSet(filters.FilterSet):
+    # This seems to be required due to the many-to-many relationships?
     atoms__name__exact = filters.CharFilter(field_name='atoms__name', lookup_expr='exact')
+    atoms__name__contains = filters.CharFilter(field_name='atoms__name', lookup_expr='contains')
+    atoms__name__regex = filters.CharFilter(field_name='atoms__name', lookup_expr='regex')
+
+    hosts__name__exact = filters.CharFilter(field_name='hosts__name', lookup_expr='exact')
+    hosts__name__contains = filters.CharFilter(field_name='hosts__name', lookup_expr='contains')
+    hosts__name__regex = filters.CharFilter(field_name='hosts__name', lookup_expr='regex')
+
+    labels__name__exact = filters.CharFilter(field_name='labels__name', lookup_expr='exact')
+    labels__name__contains = filters.CharFilter(field_name='labels__name', lookup_expr='contains')
+    labels__name__regex = filters.CharFilter(field_name='labels__name', lookup_expr='regex')
 
     class Meta:
         model = HostPolicyRole

--- a/mreg/api/v1/filters.py
+++ b/mreg/api/v1/filters.py
@@ -1,5 +1,9 @@
+import operator
+from functools import reduce
 from typing import List
 
+import structlog
+from django.db.models import Q
 from django_filters import rest_framework as filters
 
 from mreg.models.base import History
@@ -11,17 +15,20 @@ from mreg.models.resource_records import (Cname, Hinfo, Loc, Mx, Naptr, Srv,
 from mreg.models.zone import (ForwardZone, ForwardZoneDelegation, NameServer,
                               ReverseZone, ReverseZoneDelegation)
 
-from django.db.models import Q
-import operator
-from functools import reduce
-
-import structlog
-
 mreg_log = structlog.getLogger(__name__)
 
 OperatorList = List[str]
 
-STRING_OPERATORS: OperatorList = ["exact", "regex", "contains", "icontains", "startswith", "istartswith", "endswith", "iendswith"]
+STRING_OPERATORS: OperatorList = [
+    "exact",
+    "regex",
+    "contains",
+    "icontains",
+    "startswith",
+    "istartswith",
+    "endswith",
+    "iendswith",
+]
 INT_OPERATORS: OperatorList = ["exact", "in", "gt", "lt"]
 EXACT_OPERATORS: OperatorList = ["exact"]
 
@@ -37,10 +44,11 @@ class BACnetIDFilterSet(filters.FilterSet):
             "id": INT_OPERATORS,
             "host": INT_OPERATORS,
             "host__comment": STRING_OPERATORS,
-            "host__contact": STRING_OPERATORS,                
+            "host__contact": STRING_OPERATORS,
             "host__name": STRING_OPERATORS,
-            "host__ttl": INT_OPERATORS,            
+            "host__ttl": INT_OPERATORS,
         }
+
 
 class CnameFilterSet(filters.FilterSet):
     class Meta:
@@ -50,14 +58,14 @@ class CnameFilterSet(filters.FilterSet):
             "created_at": INT_OPERATORS,
             "updated_at": INT_OPERATORS,
             "host": INT_OPERATORS,
-            'host__comment': STRING_OPERATORS,
-            'host__contact': STRING_OPERATORS,
-            'host__name': STRING_OPERATORS,
-            
-            'host__ttl': INT_OPERATORS,
-            'name': STRING_OPERATORS,
-            'ttl': INT_OPERATORS,
+            "host__comment": STRING_OPERATORS,
+            "host__contact": STRING_OPERATORS,
+            "host__name": STRING_OPERATORS,
+            "host__ttl": INT_OPERATORS,
+            "name": STRING_OPERATORS,
+            "ttl": INT_OPERATORS,
         }
+
 
 class ForwardZoneFilterSet(filters.FilterSet):
     class Meta:
@@ -82,13 +90,14 @@ class ForwardZoneDelegationFilterSet(filters.FilterSet):
             "comment": STRING_OPERATORS,
         }
 
+
 class HinfoFilterSet(filters.FilterSet):
     class Meta:
         model = Hinfo
         fields = {
-            'cpu': STRING_OPERATORS,
-            'host': INT_OPERATORS,
-            'os': STRING_OPERATORS,
+            "cpu": STRING_OPERATORS,
+            "host": INT_OPERATORS,
+            "os": STRING_OPERATORS,
         }
 
 
@@ -96,9 +105,14 @@ class JSONFieldFilter(filters.CharFilter):
     def filter(self, qs, value):
         mreg_log.info("JSONFieldFilter called", value=value)
         if value:
-            queries = [Q(**{f"data__{k}": v}) for k, v in self.parent.data.items() if k.startswith('data__')]
+            queries = [
+                Q(**{f"data__{k}": v})
+                for k, v in self.parent.data.items()
+                if k.startswith("data__")
+            ]
             return qs.filter(reduce(operator.and_, queries))
         return qs
+
 
 class HistoryFilterSet(filters.FilterSet):
     class Meta:
@@ -111,27 +125,28 @@ class HistoryFilterSet(filters.FilterSet):
             "name": STRING_OPERATORS,
             "model_id": INT_OPERATORS,
             "model": STRING_OPERATORS,
-            "action": STRING_OPERATORS
+            "action": STRING_OPERATORS,
         }
 
     # This is a fugly hack to make JSON filtering "work"
     def filter_queryset(self, queryset):
-        data_filters = {k: v for k, v in self.data.items() if k.startswith('data__')}
-        
+        data_filters = {k: v for k, v in self.data.items() if k.startswith("data__")}
+
         if data_filters:
             queries = []
             for key, value in data_filters.items():
-                json_key = key.split('data__')[1]
-                if '__in' in json_key:
-                    json_key = json_key.split('__in')[0]
-                    values = value.split(',')
+                json_key = key.split("data__")[1]
+                if "__in" in json_key:
+                    json_key = json_key.split("__in")[0]
+                    values = value.split(",")
                     queries.append(Q(**{f"data__{json_key}__in": values}))
                 else:
                     queries.append(Q(**{f"data__{json_key}": value}))
-            
+
             queryset = queryset.filter(reduce(operator.and_, queries))
-        
+
         return super().filter_queryset(queryset)
+
 
 class HostFilterSet(filters.FilterSet):
     class Meta:
@@ -178,27 +193,26 @@ class HostFilterSet(filters.FilterSet):
         }
 
 
-
 class HostGroupFilterSet(filters.FilterSet):
     class Meta:
         model = HostGroup
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'description': STRING_OPERATORS,
-            'hosts': INT_OPERATORS,
-            'name': STRING_OPERATORS,
-            'owners': INT_OPERATORS,
-            'parent': INT_OPERATORS,
-        }        
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "description": STRING_OPERATORS,
+            "hosts": INT_OPERATORS,
+            "name": STRING_OPERATORS,
+            "owners": INT_OPERATORS,
+            "parent": INT_OPERATORS,
+        }
 
 
 class IpaddressFilterSet(filters.FilterSet):
     class Meta:
         model = Ipaddress
         fields = {
-            'id': INT_OPERATORS,
+            "id": INT_OPERATORS,
             "ipaddress": STRING_OPERATORS,
             "macaddress": STRING_OPERATORS,
             "host": INT_OPERATORS,
@@ -206,18 +220,18 @@ class IpaddressFilterSet(filters.FilterSet):
             "host__ttl": INT_OPERATORS,
             "host__contact": STRING_OPERATORS,
             "host__comment": STRING_OPERATORS,
-            
         }
+
 
 class LabelFilterSet(filters.FilterSet):
     class Meta:
         model = Label
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'description': STRING_OPERATORS,
-            'name': STRING_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "description": STRING_OPERATORS,
+            "name": STRING_OPERATORS,
         }
 
 
@@ -225,13 +239,12 @@ class LocFilterSet(filters.FilterSet):
     class Meta:
         model = Loc
         fields = {
-            'host': INT_OPERATORS,
-            'host__comment': STRING_OPERATORS,
-            'host__contact': STRING_OPERATORS,
-            
-            'host__name': STRING_OPERATORS,
-            'host__ttl': INT_OPERATORS,
-            'loc': STRING_OPERATORS,
+            "host": INT_OPERATORS,
+            "host__comment": STRING_OPERATORS,
+            "host__contact": STRING_OPERATORS,
+            "host__name": STRING_OPERATORS,
+            "host__ttl": INT_OPERATORS,
+            "loc": STRING_OPERATORS,
         }
 
 
@@ -239,17 +252,16 @@ class MxFilterSet(filters.FilterSet):
     class Meta:
         model = Mx
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'host': INT_OPERATORS   ,
-            'host__comment': STRING_OPERATORS,
-            'host__contact': STRING_OPERATORS,
-            
-            'host__name': STRING_OPERATORS,
-            'host__ttl': INT_OPERATORS,
-            'priority': INT_OPERATORS,
-            'mx': STRING_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "host": INT_OPERATORS,
+            "host__comment": STRING_OPERATORS,
+            "host__contact": STRING_OPERATORS,
+            "host__name": STRING_OPERATORS,
+            "host__ttl": INT_OPERATORS,
+            "priority": INT_OPERATORS,
+            "mx": STRING_OPERATORS,
         }
 
 
@@ -257,34 +269,32 @@ class NameServerFilterSet(filters.FilterSet):
     class Meta:
         model = NameServer
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'name': STRING_OPERATORS,
-            'ttl': INT_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "name": STRING_OPERATORS,
+            "ttl": INT_OPERATORS,
         }
-
 
 
 class NaptrFilterSet(filters.FilterSet):
     class Meta:
         model = Naptr
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'host': INT_OPERATORS,
-            'host__comment': STRING_OPERATORS,
-            'host__contact': STRING_OPERATORS,
-            
-            'host__name': STRING_OPERATORS,
-            'host__ttl': INT_OPERATORS,
-            'preference': INT_OPERATORS,
-            'order': INT_OPERATORS,
-            'flag': STRING_OPERATORS,
-            'service': STRING_OPERATORS,
-            'regex': STRING_OPERATORS,
-            'replacement': STRING_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "host": INT_OPERATORS,
+            "host__comment": STRING_OPERATORS,
+            "host__contact": STRING_OPERATORS,
+            "host__name": STRING_OPERATORS,
+            "host__ttl": INT_OPERATORS,
+            "preference": INT_OPERATORS,
+            "order": INT_OPERATORS,
+            "flag": STRING_OPERATORS,
+            "service": STRING_OPERATORS,
+            "regex": STRING_OPERATORS,
+            "replacement": STRING_OPERATORS,
         }
 
 
@@ -294,12 +304,12 @@ class NetGroupRegexPermissionFilterSet(filters.FilterSet):
     class Meta:
         model = NetGroupRegexPermission
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'group': STRING_OPERATORS,
-            'regex': STRING_OPERATORS,
-            'labels': INT_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "group": STRING_OPERATORS,
+            "regex": STRING_OPERATORS,
+            "labels": INT_OPERATORS,
         }
 
 
@@ -309,37 +319,36 @@ class NetworkFilterSet(filters.FilterSet):
     class Meta:
         model = Network
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'description': STRING_OPERATORS,
-            'vlan': INT_OPERATORS,
-            'dns_delegated': EXACT_OPERATORS,
-            'category': STRING_OPERATORS,
-            'location': STRING_OPERATORS,
-            'frozen': EXACT_OPERATORS,
-            'reserved': INT_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "description": STRING_OPERATORS,
+            "vlan": INT_OPERATORS,
+            "dns_delegated": EXACT_OPERATORS,
+            "category": STRING_OPERATORS,
+            "location": STRING_OPERATORS,
+            "frozen": EXACT_OPERATORS,
+            "reserved": INT_OPERATORS,
         }
-        
 
 
 class NetworkExcludedRangeFilterSet(filters.FilterSet):
     class Meta:
         model = NetworkExcludedRange
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'network': INT_OPERATORS,
-            'network__description': STRING_OPERATORS,
-            'network__vlan': INT_OPERATORS,
-            'network__dns_delegated': EXACT_OPERATORS,
-            'network__category': STRING_OPERATORS,
-            'network__location': STRING_OPERATORS,
-            'network__frozen': EXACT_OPERATORS,
-            'network__reserved': INT_OPERATORS,            
-            'start_ip': STRING_OPERATORS,
-            'end_ip': STRING_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "network": INT_OPERATORS,
+            "network__description": STRING_OPERATORS,
+            "network__vlan": INT_OPERATORS,
+            "network__dns_delegated": EXACT_OPERATORS,
+            "network__category": STRING_OPERATORS,
+            "network__location": STRING_OPERATORS,
+            "network__frozen": EXACT_OPERATORS,
+            "network__reserved": INT_OPERATORS,
+            "start_ip": STRING_OPERATORS,
+            "end_ip": STRING_OPERATORS,
         }
 
 
@@ -347,16 +356,15 @@ class PtrOverrideFilterSet(filters.FilterSet):
     class Meta:
         model = PtrOverride
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'host': INT_OPERATORS,
-            'host__comment': STRING_OPERATORS,
-            'host__contact': STRING_OPERATORS,
-            
-            'host__name': STRING_OPERATORS,
-            'host__ttl': INT_OPERATORS,
-            'ipaddress': EXACT_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "host": INT_OPERATORS,
+            "host__comment": STRING_OPERATORS,
+            "host__contact": STRING_OPERATORS,
+            "host__name": STRING_OPERATORS,
+            "host__ttl": INT_OPERATORS,
+            "ipaddress": EXACT_OPERATORS,
         }
 
 
@@ -366,10 +374,10 @@ class ReverseZoneFilterSet(filters.FilterSet):
     class Meta:
         model = ReverseZone
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'name': STRING_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "name": STRING_OPERATORS,
         }
 
 
@@ -377,14 +385,14 @@ class ReverseZoneDelegationFilterSet(filters.FilterSet):
     class Meta:
         model = ReverseZoneDelegation
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'name': STRING_OPERATORS,
-            'nameservers': INT_OPERATORS,
-            'comment': STRING_OPERATORS,
-            'zone': INT_OPERATORS,
-            'zone__name': STRING_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "name": STRING_OPERATORS,
+            "nameservers": INT_OPERATORS,
+            "comment": STRING_OPERATORS,
+            "zone": INT_OPERATORS,
+            "zone__name": STRING_OPERATORS,
         }
 
 
@@ -392,20 +400,19 @@ class SrvFilterSet(filters.FilterSet):
     class Meta:
         model = Srv
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'host': INT_OPERATORS,
-            'host__comment': STRING_OPERATORS,
-            'host__contact': STRING_OPERATORS,
-            
-            'host__name': STRING_OPERATORS,
-            'host__ttl': INT_OPERATORS,
-            'name': STRING_OPERATORS,
-            'priority': INT_OPERATORS,
-            'weight': INT_OPERATORS,
-            'port': INT_OPERATORS,
-            'ttl': INT_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "host": INT_OPERATORS,
+            "host__comment": STRING_OPERATORS,
+            "host__contact": STRING_OPERATORS,
+            "host__name": STRING_OPERATORS,
+            "host__ttl": INT_OPERATORS,
+            "name": STRING_OPERATORS,
+            "priority": INT_OPERATORS,
+            "weight": INT_OPERATORS,
+            "port": INT_OPERATORS,
+            "ttl": INT_OPERATORS,
         }
 
 
@@ -413,18 +420,17 @@ class SshfpFilterSet(filters.FilterSet):
     class Meta:
         model = Sshfp
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'host': INT_OPERATORS,
-            'host__comment': STRING_OPERATORS,
-            'host__contact': STRING_OPERATORS,
-            
-            'host__name': STRING_OPERATORS,
-            'host__ttl': INT_OPERATORS,
-            'algorithm': INT_OPERATORS,
-            'hash_type': INT_OPERATORS,
-            'fingerprint': STRING_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "host": INT_OPERATORS,
+            "host__comment": STRING_OPERATORS,
+            "host__contact": STRING_OPERATORS,
+            "host__name": STRING_OPERATORS,
+            "host__ttl": INT_OPERATORS,
+            "algorithm": INT_OPERATORS,
+            "hash_type": INT_OPERATORS,
+            "fingerprint": STRING_OPERATORS,
         }
 
 
@@ -432,13 +438,13 @@ class TxtFilterSet(filters.FilterSet):
     class Meta:
         model = Txt
         fields = {
-            'id': INT_OPERATORS,
-            'created_at': INT_OPERATORS,
-            'updated_at': INT_OPERATORS,
-            'host': INT_OPERATORS,
-            'host__comment': STRING_OPERATORS,
-            'host__contact': STRING_OPERATORS,
-            'host__name': STRING_OPERATORS,
-            'host__ttl': INT_OPERATORS,
-            'txt': STRING_OPERATORS,
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "host": INT_OPERATORS,
+            "host__comment": STRING_OPERATORS,
+            "host__contact": STRING_OPERATORS,
+            "host__name": STRING_OPERATORS,
+            "host__ttl": INT_OPERATORS,
+            "txt": STRING_OPERATORS,
         }

--- a/mreg/api/v1/filters.py
+++ b/mreg/api/v1/filters.py
@@ -1,177 +1,444 @@
+from typing import List
+
 from django_filters import rest_framework as filters
 
 from mreg.models.base import History
 from mreg.models.host import BACnetID, Host, HostGroup, Ipaddress, PtrOverride
-from mreg.models.network import (
-    Label,
-    NetGroupRegexPermission,
-    Network,
-    NetworkExcludedRange,
-)
-from mreg.models.resource_records import Cname, Hinfo, Loc, Mx, Naptr, Srv, Sshfp, Txt
-from mreg.models.zone import (
-    ForwardZone,
-    ForwardZoneDelegation,
-    NameServer,
-    ReverseZone,
-    ReverseZoneDelegation,
-)
+from mreg.models.network import (Label, NetGroupRegexPermission, Network,
+                                 NetworkExcludedRange)
+from mreg.models.resource_records import (Cname, Hinfo, Loc, Mx, Naptr, Srv,
+                                          Sshfp, Txt)
+from mreg.models.zone import (ForwardZone, ForwardZoneDelegation, NameServer,
+                              ReverseZone, ReverseZoneDelegation)
 
-class FilterWithID(filters.FilterSet):
-    id = filters.NumberFilter(field_name="id")
-    id__in = filters.BaseInFilter(field_name="id")
-    id__gt = filters.NumberFilter(field_name="id", lookup_expr="gt")
-    id__lt = filters.NumberFilter(field_name="id", lookup_expr="lt")
+from django.db.models import Q
+import operator
+from functools import reduce
 
+import structlog
 
-class JSONFieldExactFilter(filters.CharFilter):
-    pass
+mreg_log = structlog.getLogger(__name__)
+
+OperatorList = List[str]
+
+STRING_OPERATORS: OperatorList = ["exact", "regex", "contains", "icontains", "startswith", "istartswith", "endswith", "iendswith"]
+INT_OPERATORS: OperatorList = ["exact", "in", "gt", "lt"]
+EXACT_OPERATORS: OperatorList = ["exact"]
 
 
 class CIDRFieldExactFilter(filters.CharFilter):
     pass
 
 
-class BACnetIDFilterSet(FilterWithID):
+class BACnetIDFilterSet(filters.FilterSet):
     class Meta:
         model = BACnetID
-        fields = "__all__"
+        fields = {
+            "id": INT_OPERATORS,
+            "host": INT_OPERATORS,
+            "host__comment": STRING_OPERATORS,
+            "host__contact": STRING_OPERATORS,                
+            "host__name": STRING_OPERATORS,
+            "host__ttl": INT_OPERATORS,            
+        }
 
-
-class CnameFilterSet(FilterWithID):
+class CnameFilterSet(filters.FilterSet):
     class Meta:
         model = Cname
-        fields = "__all__"
+        fields = {
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "host": INT_OPERATORS,
+            'host__comment': STRING_OPERATORS,
+            'host__contact': STRING_OPERATORS,
+            'host__name': STRING_OPERATORS,
+            
+            'host__ttl': INT_OPERATORS,
+            'name': STRING_OPERATORS,
+            'ttl': INT_OPERATORS,
+        }
 
-
-class ForwardZoneFilterSet(FilterWithID):
+class ForwardZoneFilterSet(filters.FilterSet):
     class Meta:
         model = ForwardZone
-        fields = "__all__"
+        fields = {
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "name": STRING_OPERATORS,
+        }
 
 
-class ForwardZoneDelegationFilterSet(FilterWithID):
+class ForwardZoneDelegationFilterSet(filters.FilterSet):
     class Meta:
         model = ForwardZoneDelegation
-        fields = "__all__"
+        fields = {
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "name": STRING_OPERATORS,
+            "nameservers": INT_OPERATORS,
+            "comment": STRING_OPERATORS,
+        }
 
-
-class HinfoFilterSet(FilterWithID):
+class HinfoFilterSet(filters.FilterSet):
     class Meta:
         model = Hinfo
-        fields = "__all__"
+        fields = {
+            'cpu': STRING_OPERATORS,
+            'host': INT_OPERATORS,
+            'os': STRING_OPERATORS,
+        }
 
 
-class HistoryFilterSet(FilterWithID):
-    data = JSONFieldExactFilter(field_name="data")
+class JSONFieldFilter(filters.CharFilter):
+    def filter(self, qs, value):
+        mreg_log.info("JSONFieldFilter called", value=value)
+        if value:
+            queries = [Q(**{f"data__{k}": v}) for k, v in self.parent.data.items() if k.startswith('data__')]
+            return qs.filter(reduce(operator.and_, queries))
+        return qs
 
+class HistoryFilterSet(filters.FilterSet):
     class Meta:
         model = History
-        fields = "__all__"
+        fields = {
+            "id": INT_OPERATORS,
+            "timestamp": INT_OPERATORS,
+            "user": STRING_OPERATORS,
+            "resource": STRING_OPERATORS,
+            "name": STRING_OPERATORS,
+            "model_id": INT_OPERATORS,
+            "model": STRING_OPERATORS,
+            "action": STRING_OPERATORS
+        }
 
+    # This is a fugly hack to make JSON filtering "work"
+    def filter_queryset(self, queryset):
+        data_filters = {k: v for k, v in self.data.items() if k.startswith('data__')}
+        
+        if data_filters:
+            queries = []
+            for key, value in data_filters.items():
+                json_key = key.split('data__')[1]
+                if '__in' in json_key:
+                    json_key = json_key.split('__in')[0]
+                    values = value.split(',')
+                    queries.append(Q(**{f"data__{json_key}__in": values}))
+                else:
+                    queries.append(Q(**{f"data__{json_key}": value}))
+            
+            queryset = queryset.filter(reduce(operator.and_, queries))
+        
+        return super().filter_queryset(queryset)
 
-class HostFilterSet(FilterWithID):
+class HostFilterSet(filters.FilterSet):
     class Meta:
         model = Host
-        fields = "__all__"
+        fields = {
+            "id": INT_OPERATORS,
+            "created_at": INT_OPERATORS,
+            "updated_at": INT_OPERATORS,
+            "name": STRING_OPERATORS,
+            "contact": STRING_OPERATORS,
+            "ttl": INT_OPERATORS,
+            "comment": STRING_OPERATORS,
+            # These are related fields, ie, inverse relationships
+            "ipaddresses": INT_OPERATORS,
+            "ipaddresses__ipaddress": EXACT_OPERATORS,
+            "ipaddresses__macaddress": STRING_OPERATORS,
+            "ptr_overrides": INT_OPERATORS,
+            "ptr_overrides__ipaddress": EXACT_OPERATORS,
+            "hostgroups": INT_OPERATORS,
+            "hostgroups__name": STRING_OPERATORS,
+            "hostgroups__description": STRING_OPERATORS,
+            "bacnetid": INT_OPERATORS,
+            "mxs": INT_OPERATORS,
+            "mxs__priority": INT_OPERATORS,
+            "mxs__mx": STRING_OPERATORS,
+            "txts": INT_OPERATORS,
+            "txts__txt": STRING_OPERATORS,
+            "cnames": INT_OPERATORS,
+            "cnames__name": STRING_OPERATORS,
+            "cnames__ttl": INT_OPERATORS,
+            "naptrs": INT_OPERATORS,
+            "naptrs__order": INT_OPERATORS,
+            "naptrs__preference": INT_OPERATORS,
+            "naptrs__flag": STRING_OPERATORS,
+            "naptrs__service": STRING_OPERATORS,
+            "naptrs__regex": STRING_OPERATORS,
+            "naptrs__replacement": STRING_OPERATORS,
+            "srvs": INT_OPERATORS,
+            "srvs__name": STRING_OPERATORS,
+            "srvs__priority": INT_OPERATORS,
+            "srvs__weight": INT_OPERATORS,
+            "srvs__port": INT_OPERATORS,
+            "srvs__ttl": INT_OPERATORS,
+        }
 
 
-class HostGroupFilterSet(FilterWithID):
+
+class HostGroupFilterSet(filters.FilterSet):
     class Meta:
         model = HostGroup
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'description': STRING_OPERATORS,
+            'hosts': INT_OPERATORS,
+            'name': STRING_OPERATORS,
+            'owners': INT_OPERATORS,
+            'parent': INT_OPERATORS,
+        }        
 
 
-class IpaddressFilterSet(FilterWithID):
+class IpaddressFilterSet(filters.FilterSet):
     class Meta:
         model = Ipaddress
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            "ipaddress": STRING_OPERATORS,
+            "macaddress": STRING_OPERATORS,
+            "host": INT_OPERATORS,
+            "host__name": STRING_OPERATORS,
+            "host__ttl": INT_OPERATORS,
+            "host__contact": STRING_OPERATORS,
+            "host__comment": STRING_OPERATORS,
+            
+        }
 
-
-class LabelFilterSet(FilterWithID):
+class LabelFilterSet(filters.FilterSet):
     class Meta:
         model = Label
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'description': STRING_OPERATORS,
+            'name': STRING_OPERATORS,
+        }
 
 
-class LocFilterSet(FilterWithID):
+class LocFilterSet(filters.FilterSet):
     class Meta:
         model = Loc
-        fields = "__all__"
+        fields = {
+            'host': INT_OPERATORS,
+            'host__comment': STRING_OPERATORS,
+            'host__contact': STRING_OPERATORS,
+            
+            'host__name': STRING_OPERATORS,
+            'host__ttl': INT_OPERATORS,
+            'loc': STRING_OPERATORS,
+        }
 
 
-class MxFilterSet(FilterWithID):
+class MxFilterSet(filters.FilterSet):
     class Meta:
         model = Mx
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'host': INT_OPERATORS   ,
+            'host__comment': STRING_OPERATORS,
+            'host__contact': STRING_OPERATORS,
+            
+            'host__name': STRING_OPERATORS,
+            'host__ttl': INT_OPERATORS,
+            'priority': INT_OPERATORS,
+            'mx': STRING_OPERATORS,
+        }
 
 
-class NameServerFilterSet(FilterWithID):
+class NameServerFilterSet(filters.FilterSet):
     class Meta:
         model = NameServer
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'name': STRING_OPERATORS,
+            'ttl': INT_OPERATORS,
+        }
 
 
-class NaptrFilterSet(FilterWithID):
+
+class NaptrFilterSet(filters.FilterSet):
     class Meta:
         model = Naptr
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'host': INT_OPERATORS,
+            'host__comment': STRING_OPERATORS,
+            'host__contact': STRING_OPERATORS,
+            
+            'host__name': STRING_OPERATORS,
+            'host__ttl': INT_OPERATORS,
+            'preference': INT_OPERATORS,
+            'order': INT_OPERATORS,
+            'flag': STRING_OPERATORS,
+            'service': STRING_OPERATORS,
+            'regex': STRING_OPERATORS,
+            'replacement': STRING_OPERATORS,
+        }
 
 
-class NetGroupRegexPermissionFilterSet(FilterWithID):
+class NetGroupRegexPermissionFilterSet(filters.FilterSet):
     range = CIDRFieldExactFilter(field_name="range")
 
     class Meta:
         model = NetGroupRegexPermission
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'group': STRING_OPERATORS,
+            'regex': STRING_OPERATORS,
+            'labels': INT_OPERATORS,
+        }
 
 
-class NetworkFilterSet(FilterWithID):
+class NetworkFilterSet(filters.FilterSet):
     network = CIDRFieldExactFilter(field_name="network")
 
     class Meta:
         model = Network
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'description': STRING_OPERATORS,
+            'vlan': INT_OPERATORS,
+            'dns_delegated': EXACT_OPERATORS,
+            'category': STRING_OPERATORS,
+            'location': STRING_OPERATORS,
+            'frozen': EXACT_OPERATORS,
+            'reserved': INT_OPERATORS,
+        }
+        
 
 
-class NetworkExcludedRangeFilterSet(FilterWithID):
+class NetworkExcludedRangeFilterSet(filters.FilterSet):
     class Meta:
         model = NetworkExcludedRange
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'network': INT_OPERATORS,
+            'network__description': STRING_OPERATORS,
+            'network__vlan': INT_OPERATORS,
+            'network__dns_delegated': EXACT_OPERATORS,
+            'network__category': STRING_OPERATORS,
+            'network__location': STRING_OPERATORS,
+            'network__frozen': EXACT_OPERATORS,
+            'network__reserved': INT_OPERATORS,            
+            'start_ip': STRING_OPERATORS,
+            'end_ip': STRING_OPERATORS,
+        }
 
 
-class PtrOverrideFilterSet(FilterWithID):
+class PtrOverrideFilterSet(filters.FilterSet):
     class Meta:
         model = PtrOverride
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'host': INT_OPERATORS,
+            'host__comment': STRING_OPERATORS,
+            'host__contact': STRING_OPERATORS,
+            
+            'host__name': STRING_OPERATORS,
+            'host__ttl': INT_OPERATORS,
+            'ipaddress': EXACT_OPERATORS,
+        }
 
 
-class ReverseZoneFilterSet(FilterWithID):
+class ReverseZoneFilterSet(filters.FilterSet):
     network = CIDRFieldExactFilter(field_name="network")
 
     class Meta:
         model = ReverseZone
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'name': STRING_OPERATORS,
+        }
 
 
-class ReverseZoneDelegationFilterSet(FilterWithID):
+class ReverseZoneDelegationFilterSet(filters.FilterSet):
     class Meta:
         model = ReverseZoneDelegation
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'name': STRING_OPERATORS,
+            'nameservers': INT_OPERATORS,
+            'comment': STRING_OPERATORS,
+            'zone': INT_OPERATORS,
+            'zone__name': STRING_OPERATORS,
+        }
 
-class SrvFilterSet(FilterWithID):
+
+class SrvFilterSet(filters.FilterSet):
     class Meta:
         model = Srv
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'host': INT_OPERATORS,
+            'host__comment': STRING_OPERATORS,
+            'host__contact': STRING_OPERATORS,
+            
+            'host__name': STRING_OPERATORS,
+            'host__ttl': INT_OPERATORS,
+            'name': STRING_OPERATORS,
+            'priority': INT_OPERATORS,
+            'weight': INT_OPERATORS,
+            'port': INT_OPERATORS,
+            'ttl': INT_OPERATORS,
+        }
 
 
-class SshfpFilterSet(FilterWithID):
+class SshfpFilterSet(filters.FilterSet):
     class Meta:
         model = Sshfp
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'host': INT_OPERATORS,
+            'host__comment': STRING_OPERATORS,
+            'host__contact': STRING_OPERATORS,
+            
+            'host__name': STRING_OPERATORS,
+            'host__ttl': INT_OPERATORS,
+            'algorithm': INT_OPERATORS,
+            'hash_type': INT_OPERATORS,
+            'fingerprint': STRING_OPERATORS,
+        }
 
 
-class TxtFilterSet(FilterWithID):
+class TxtFilterSet(filters.FilterSet):
     class Meta:
         model = Txt
-        fields = "__all__"
+        fields = {
+            'id': INT_OPERATORS,
+            'created_at': INT_OPERATORS,
+            'updated_at': INT_OPERATORS,
+            'host': INT_OPERATORS,
+            'host__comment': STRING_OPERATORS,
+            'host__contact': STRING_OPERATORS,
+            'host__name': STRING_OPERATORS,
+            'host__ttl': INT_OPERATORS,
+            'txt': STRING_OPERATORS,
+        }

--- a/mreg/api/v1/filters.py
+++ b/mreg/api/v1/filters.py
@@ -32,7 +32,18 @@ STRING_OPERATORS: OperatorList = [
 INT_OPERATORS: OperatorList = ["exact", "in", "gt", "lt"]
 EXACT_OPERATORS: OperatorList = ["exact"]
 
+HOST_FIELDS = {
+    "host": INT_OPERATORS,
+    "host__comment": STRING_OPERATORS,
+    "host__contact": STRING_OPERATORS,
+    "host__name": STRING_OPERATORS,
+    "host__ttl": INT_OPERATORS,
+}
 
+CREATED_UPDATED = {
+    "created_at": INT_OPERATORS,
+    "updated_at": INT_OPERATORS,
+}
 
 class CIDRFieldExactFilter(filters.CharFilter):
     pass
@@ -43,11 +54,7 @@ class BACnetIDFilterSet(filters.FilterSet):
         model = BACnetID
         fields = {
             "id": INT_OPERATORS,
-            "host": INT_OPERATORS,
-            "host__comment": STRING_OPERATORS,
-            "host__contact": STRING_OPERATORS,
-            "host__name": STRING_OPERATORS,
-            "host__ttl": INT_OPERATORS,
+            **HOST_FIELDS,
         }
 
 
@@ -56,15 +63,10 @@ class CnameFilterSet(filters.FilterSet):
         model = Cname
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
-            "host": INT_OPERATORS,
-            "host__comment": STRING_OPERATORS,
-            "host__contact": STRING_OPERATORS,
-            "host__name": STRING_OPERATORS,
-            "host__ttl": INT_OPERATORS,
             "name": STRING_OPERATORS,
             "ttl": INT_OPERATORS,
+            **HOST_FIELDS,
+            **CREATED_UPDATED,
         }
 
 
@@ -73,9 +75,8 @@ class ForwardZoneFilterSet(filters.FilterSet):
         model = ForwardZone
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
             "name": STRING_OPERATORS,
+            **CREATED_UPDATED,
         }
 
 
@@ -84,11 +85,10 @@ class ForwardZoneDelegationFilterSet(filters.FilterSet):
         model = ForwardZoneDelegation
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
             "name": STRING_OPERATORS,
             "nameservers": INT_OPERATORS,
             "comment": STRING_OPERATORS,
+            **CREATED_UPDATED,
         }
 
 
@@ -141,8 +141,6 @@ class HostFilterSet(filters.FilterSet):
         model = Host
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
             "name": STRING_OPERATORS,
             "contact": STRING_OPERATORS,
             "ttl": INT_OPERATORS,
@@ -178,6 +176,7 @@ class HostFilterSet(filters.FilterSet):
             "srvs__weight": INT_OPERATORS,
             "srvs__port": INT_OPERATORS,
             "srvs__ttl": INT_OPERATORS,
+            **CREATED_UPDATED,
         }
 
 
@@ -186,13 +185,12 @@ class HostGroupFilterSet(filters.FilterSet):
         model = HostGroup
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
             "description": STRING_OPERATORS,
             "hosts": INT_OPERATORS,
             "name": STRING_OPERATORS,
             "owners": INT_OPERATORS,
             "parent": INT_OPERATORS,
+            **CREATED_UPDATED,
         }
 
 
@@ -203,11 +201,7 @@ class IpaddressFilterSet(filters.FilterSet):
             "id": INT_OPERATORS,
             "ipaddress": STRING_OPERATORS,
             "macaddress": STRING_OPERATORS,
-            "host": INT_OPERATORS,
-            "host__name": STRING_OPERATORS,
-            "host__ttl": INT_OPERATORS,
-            "host__contact": STRING_OPERATORS,
-            "host__comment": STRING_OPERATORS,
+            **HOST_FIELDS,
         }
 
 
@@ -216,10 +210,9 @@ class LabelFilterSet(filters.FilterSet):
         model = Label
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
             "description": STRING_OPERATORS,
             "name": STRING_OPERATORS,
+            **CREATED_UPDATED,
         }
 
 
@@ -227,12 +220,8 @@ class LocFilterSet(filters.FilterSet):
     class Meta:
         model = Loc
         fields = {
-            "host": INT_OPERATORS,
-            "host__comment": STRING_OPERATORS,
-            "host__contact": STRING_OPERATORS,
-            "host__name": STRING_OPERATORS,
-            "host__ttl": INT_OPERATORS,
             "loc": STRING_OPERATORS,
+            **HOST_FIELDS,
         }
 
 
@@ -241,15 +230,10 @@ class MxFilterSet(filters.FilterSet):
         model = Mx
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
-            "host": INT_OPERATORS,
-            "host__comment": STRING_OPERATORS,
-            "host__contact": STRING_OPERATORS,
-            "host__name": STRING_OPERATORS,
-            "host__ttl": INT_OPERATORS,
             "priority": INT_OPERATORS,
             "mx": STRING_OPERATORS,
+            **HOST_FIELDS,
+            **CREATED_UPDATED
         }
 
 
@@ -258,10 +242,9 @@ class NameServerFilterSet(filters.FilterSet):
         model = NameServer
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
             "name": STRING_OPERATORS,
             "ttl": INT_OPERATORS,
+            **CREATED_UPDATED,
         }
 
 
@@ -270,19 +253,14 @@ class NaptrFilterSet(filters.FilterSet):
         model = Naptr
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
-            "host": INT_OPERATORS,
-            "host__comment": STRING_OPERATORS,
-            "host__contact": STRING_OPERATORS,
-            "host__name": STRING_OPERATORS,
-            "host__ttl": INT_OPERATORS,
             "preference": INT_OPERATORS,
             "order": INT_OPERATORS,
             "flag": STRING_OPERATORS,
             "service": STRING_OPERATORS,
             "regex": STRING_OPERATORS,
             "replacement": STRING_OPERATORS,
+            **HOST_FIELDS,
+            **CREATED_UPDATED,
         }
 
 
@@ -293,11 +271,10 @@ class NetGroupRegexPermissionFilterSet(filters.FilterSet):
         model = NetGroupRegexPermission
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
             "group": STRING_OPERATORS,
             "regex": STRING_OPERATORS,
             "labels": INT_OPERATORS,
+            **CREATED_UPDATED,
         }
 
 
@@ -308,8 +285,6 @@ class NetworkFilterSet(filters.FilterSet):
         model = Network
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
             "description": STRING_OPERATORS,
             "vlan": INT_OPERATORS,
             "dns_delegated": EXACT_OPERATORS,
@@ -317,6 +292,7 @@ class NetworkFilterSet(filters.FilterSet):
             "location": STRING_OPERATORS,
             "frozen": EXACT_OPERATORS,
             "reserved": INT_OPERATORS,
+            **CREATED_UPDATED,
         }
 
 
@@ -325,8 +301,6 @@ class NetworkExcludedRangeFilterSet(filters.FilterSet):
         model = NetworkExcludedRange
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
             "network": INT_OPERATORS,
             "network__description": STRING_OPERATORS,
             "network__vlan": INT_OPERATORS,
@@ -337,6 +311,7 @@ class NetworkExcludedRangeFilterSet(filters.FilterSet):
             "network__reserved": INT_OPERATORS,
             "start_ip": STRING_OPERATORS,
             "end_ip": STRING_OPERATORS,
+            **CREATED_UPDATED,
         }
 
 
@@ -345,15 +320,11 @@ class PtrOverrideFilterSet(filters.FilterSet):
         model = PtrOverride
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
-            "host": INT_OPERATORS,
-            "host__comment": STRING_OPERATORS,
-            "host__contact": STRING_OPERATORS,
-            "host__name": STRING_OPERATORS,
-            "host__ttl": INT_OPERATORS,
             "ipaddress": EXACT_OPERATORS,
+            **HOST_FIELDS,
+            **CREATED_UPDATED,
         }
+
 
 
 class ReverseZoneFilterSet(filters.FilterSet):
@@ -363,9 +334,8 @@ class ReverseZoneFilterSet(filters.FilterSet):
         model = ReverseZone
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
             "name": STRING_OPERATORS,
+            **CREATED_UPDATED,
         }
 
 
@@ -374,13 +344,12 @@ class ReverseZoneDelegationFilterSet(filters.FilterSet):
         model = ReverseZoneDelegation
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
             "name": STRING_OPERATORS,
             "nameservers": INT_OPERATORS,
             "comment": STRING_OPERATORS,
             "zone": INT_OPERATORS,
             "zone__name": STRING_OPERATORS,
+            **CREATED_UPDATED,
         }
 
 
@@ -389,18 +358,13 @@ class SrvFilterSet(filters.FilterSet):
         model = Srv
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
-            "host": INT_OPERATORS,
-            "host__comment": STRING_OPERATORS,
-            "host__contact": STRING_OPERATORS,
-            "host__name": STRING_OPERATORS,
-            "host__ttl": INT_OPERATORS,
             "name": STRING_OPERATORS,
             "priority": INT_OPERATORS,
             "weight": INT_OPERATORS,
             "port": INT_OPERATORS,
             "ttl": INT_OPERATORS,
+            **HOST_FIELDS,
+            **CREATED_UPDATED,
         }
 
 
@@ -409,16 +373,11 @@ class SshfpFilterSet(filters.FilterSet):
         model = Sshfp
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
-            "host": INT_OPERATORS,
-            "host__comment": STRING_OPERATORS,
-            "host__contact": STRING_OPERATORS,
-            "host__name": STRING_OPERATORS,
-            "host__ttl": INT_OPERATORS,
             "algorithm": INT_OPERATORS,
             "hash_type": INT_OPERATORS,
             "fingerprint": STRING_OPERATORS,
+            **HOST_FIELDS,
+            **CREATED_UPDATED,
         }
 
 
@@ -427,12 +386,7 @@ class TxtFilterSet(filters.FilterSet):
         model = Txt
         fields = {
             "id": INT_OPERATORS,
-            "created_at": INT_OPERATORS,
-            "updated_at": INT_OPERATORS,
-            "host": INT_OPERATORS,
-            "host__comment": STRING_OPERATORS,
-            "host__contact": STRING_OPERATORS,
-            "host__name": STRING_OPERATORS,
-            "host__ttl": INT_OPERATORS,
             "txt": STRING_OPERATORS,
+            **HOST_FIELDS,
+            **CREATED_UPDATED,
         }

--- a/mreg/api/v1/filters.py
+++ b/mreg/api/v1/filters.py
@@ -21,6 +21,7 @@ OperatorList = List[str]
 
 STRING_OPERATORS: OperatorList = [
     "exact",
+    "iexact",
     "regex",
     "contains",
     "icontains",

--- a/mreg/api/v1/filters.py
+++ b/mreg/api/v1/filters.py
@@ -1,4 +1,3 @@
-import json
 import operator
 from functools import reduce
 from typing import List
@@ -33,32 +32,6 @@ STRING_OPERATORS: OperatorList = [
 INT_OPERATORS: OperatorList = ["exact", "in", "gt", "lt"]
 EXACT_OPERATORS: OperatorList = ["exact"]
 
-
-class JSONFieldFilter(filters.CharFilter):
-    def filter(self, qs, value):
-        if not value:
-            return qs
-
-        queries = []
-        for k, v in self.parent.data.items():
-            if k.startswith("data__"):
-                json_key = k.split("data__", 1)[1]
-
-                if json_key.endswith("__in"):
-                    json_key = json_key[:-4]
-                    try:
-                        values = json.loads(v)
-                        if not isinstance(values, list):
-                            continue
-                    except json.JSONDecodeError:
-                        continue
-                    queries.append(Q(**{f"data__{json_key}__in": values}))
-                else:
-                    queries.append(Q(**{f"data__{json_key}": v}))
-
-        if queries:
-            return qs.filter(reduce(operator.and_, queries))
-        return qs
 
 
 class CIDRFieldExactFilter(filters.CharFilter):

--- a/mreg/api/v1/tests/test_filtering.py
+++ b/mreg/api/v1/tests/test_filtering.py
@@ -23,6 +23,10 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
             param("hosts", "name", "hostsname0.example.com", 1, id="hosts_name"),
             param("cnames", "host__name",  "cnameshostname1.example.com", 1, id="cnames_host__name"),
             param("cnames", "host__name__icontains",  "cnameshostnameicontains", 3, id="cnames_host__icontains"),
+            param("cnames", "host__name__iexact",  "cnameshostnameiexact1.example.com", 1, id="cnames_host__iexact"),
+            param("cnames", "host__name__startswith",  "cnameshostnamestartswith", 3, id="cnames_host__startswith"),
+            param("cnames", "host__name__endswith",  "endswith2.example.com", 1, id="cnames_host__endswith"),
+            param("cnames", "host__name__regex",  "cnameshostnameregex[0-9]", 3, id="cnames_host__regex"),
         ],
 
     )

--- a/mreg/api/v1/tests/test_filtering.py
+++ b/mreg/api/v1/tests/test_filtering.py
@@ -1,14 +1,12 @@
 
 from typing import List
 
+from unittest_parametrize import ParametrizedTestCase, param, parametrize
+
 from mreg.models.host import Host
 from mreg.models.resource_records import Cname
 
 from .tests import MregAPITestCase
-
-from unittest_parametrize import param
-from unittest_parametrize import parametrize
-from unittest_parametrize import ParametrizedTestCase
 
 
 class FilterTestCase(ParametrizedTestCase, MregAPITestCase):

--- a/mreg/api/v1/tests/test_filtering.py
+++ b/mreg/api/v1/tests/test_filtering.py
@@ -224,3 +224,23 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
 
         for obj in chain(roles, atoms, labels, hosts):
             obj.delete()
+
+    def test_filtering_on_host_id(self) -> None:
+        """Test filtering on host id."""
+
+        generate_count = 3
+        hosts = create_hosts("hosts", generate_count)
+
+        for host in hosts:
+            with self.subTest(host=host):
+                id = host.id # type: ignore
+                msg_prefix = f"hosts : id -> {id} => "
+
+                response = self.client.get(f"/api/v1/hosts/?id={id}")
+                self.assertEqual(response.status_code, 200, msg=f"{msg_prefix} {response.content}")
+                data = response.json()
+                self.assertEqual(data["results"][0]["id"], id, msg=f"{msg_prefix} {data}")
+                self.assertEqual(data["count"], 1, msg=f"{msg_prefix} {data}")
+
+        for obj in hosts:
+            obj.delete()

--- a/mreg/api/v1/tests/test_filtering.py
+++ b/mreg/api/v1/tests/test_filtering.py
@@ -58,6 +58,7 @@ def create_ipaddresses(hosts: List[Host]) -> List[Ipaddress]:
 
     return ipaddresses
 
+
 def create_labels(name: str, count: int) -> List[Label]:
     """Create labels."""
 
@@ -71,6 +72,7 @@ def create_labels(name: str, count: int) -> List[Label]:
         )
 
     return labels
+
 
 def create_atoms(name: str, count: int) -> List[HostPolicyAtom]:
     """Create atoms."""
@@ -104,17 +106,11 @@ def create_roles(
     roles: List[HostPolicyRole] = []
 
     for i, h in enumerate(hosts):
-        policy = HostPolicyRole.objects.create(
-                name=f"{name}host{i}".replace("_", ""),
-                description="Test role")
-        
+        policy = HostPolicyRole.objects.create(name=f"{name}host{i}".replace("_", ""), description="Test role")
         policy.hosts.add(h)
         policy.labels.add(labels[i])
         policy.atoms.add(atoms[i])
-
         roles.append(policy)
-        
-
     return (roles, atoms, labels)
 
 
@@ -126,7 +122,9 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
     # NOTE: The generated hostnames are UNIQUE across every test case!
     # The format is: f"{endpoint}{query_key}{i}.example.com".replace("_", "")
     # where i is the index of the hostname (and we make three for each test).
-    @parametrize(("endpoint", "query_key", "target", "expected_hits"), [
+    @parametrize(
+        ("endpoint", "query_key", "target", "expected_hits"),
+        [
             # Direct host filtering
             param("hosts", "name", "hostsname0.example.com", 1, id="hosts_name"),
             param("hosts", "name__contains", "namecontains1", 1, id="hosts_name__contains"),
@@ -171,40 +169,37 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
         for obj in chain(ipadresses, cnames, hosts):
             obj.delete()
 
-    @parametrize(("endpoint", "query_key", "target", "expected_hits"), [
-        param("roles", "name", "roleshost0", 1, id="roles_name"),
-        param("roles", "name__contains", "roleshost1", 1, id="roles_name__contains"),
-        param("roles", "name__icontains", "roleshost2", 1, id="roles_name__icontains"),
-        param("roles", "name__iexact", "roleshost2", 1, id="roles_name__iexact"),
-        param("roles", "name__startswith", "roleshost1", 1, id="roles_name__startswith"),
-        param("roles", "name__endswith", "host1", 1, id="roles_name__endswith"),
-        param("roles", "name__regex", "roleshost[0-1]", 2, id="roles_name__regex"),
-
-        param("roles", "atoms__name__exact", "rolesatomsnameexact1", 1, id="roles_atoms__name__exact"),
-        param("roles", "atoms__name__contains", "namecontains1", 1, id="roles_atoms__name__contains"),
-        param("roles", "atoms__name__regex", "nameregex[0-1]", 2, id="roles_atoms__name__regex"),
-
-        param("roles", "hosts__name__exact", "roleshostsnameexact1.example.com", 1, id="roles_hosts__name__exact"),
-        param("roles", "hosts__name__contains", "namecontains1", 1, id="roles_hosts__name__contains"),
-        param("roles", "hosts__name__regex", "nameregex[0-1].example.com", 2, id="roles_hosts__name__regex"),
-
-        param("roles", "labels__name__exact", "roleslabelsnameexact1", 1, id="roles_labels__name__exact"),
-        param("roles", "labels__name__contains", "namecontains1", 1, id="roles_labels__name__contains"),
-        param("roles", "labels__name__regex", "nameregex[0-1]", 2, id="roles_labels__name__regex"),
-
-        param("atoms", "name", "atomsname0", 1, id="atoms_name"),
-        param("atoms", "name__contains", "namecontains1", 1, id="atoms_name__contains"),
-        param("atoms", "name__icontains", "nameicontains2", 1, id="atoms_name__icontains"),
-        param("atoms", "name__iexact", "atomsnameiexact2", 1, id="atoms_name__iexact"),
-        param("atoms", "name__startswith", "atomsnamestartswith1", 1, id="atoms_name__startswith"),
-        param("atoms", "name__endswith", "endswith0", 1, id="atoms_name__endswith"),
-        param("atoms", "name__regex", "nameregex[0-1]", 2, id="atoms_name__regex"),
-
-        param("atoms", "description", "Test atom 1", 1, id="atoms_description"),
-        param("atoms", "description__contains", "Test atom", 3, id="atoms_description__contains"),
-        param("atoms", "description__regex", "Test atom [0-1]", 2, id="atoms_description__regex"),
-
-    ])
+    @parametrize(
+        ("endpoint", "query_key", "target", "expected_hits"),
+        [
+            param("roles", "name", "roleshost0", 1, id="roles_name"),
+            param("roles", "name__contains", "roleshost1", 1, id="roles_name__contains"),
+            param("roles", "name__icontains", "roleshost2", 1, id="roles_name__icontains"),
+            param("roles", "name__iexact", "roleshost2", 1, id="roles_name__iexact"),
+            param("roles", "name__startswith", "roleshost1", 1, id="roles_name__startswith"),
+            param("roles", "name__endswith", "host1", 1, id="roles_name__endswith"),
+            param("roles", "name__regex", "roleshost[0-1]", 2, id="roles_name__regex"),
+            param("roles", "atoms__name__exact", "rolesatomsnameexact1", 1, id="roles_atoms__name__exact"),
+            param("roles", "atoms__name__contains", "namecontains1", 1, id="roles_atoms__name__contains"),
+            param("roles", "atoms__name__regex", "nameregex[0-1]", 2, id="roles_atoms__name__regex"),
+            param("roles", "hosts__name__exact", "roleshostsnameexact1.example.com", 1, id="roles_hosts__name__exact"),
+            param("roles", "hosts__name__contains", "namecontains1", 1, id="roles_hosts__name__contains"),
+            param("roles", "hosts__name__regex", "nameregex[0-1].example.com", 2, id="roles_hosts__name__regex"),
+            param("roles", "labels__name__exact", "roleslabelsnameexact1", 1, id="roles_labels__name__exact"),
+            param("roles", "labels__name__contains", "namecontains1", 1, id="roles_labels__name__contains"),
+            param("roles", "labels__name__regex", "nameregex[0-1]", 2, id="roles_labels__name__regex"),
+            param("atoms", "name", "atomsname0", 1, id="atoms_name"),
+            param("atoms", "name__contains", "namecontains1", 1, id="atoms_name__contains"),
+            param("atoms", "name__icontains", "nameicontains2", 1, id="atoms_name__icontains"),
+            param("atoms", "name__iexact", "atomsnameiexact2", 1, id="atoms_name__iexact"),
+            param("atoms", "name__startswith", "atomsnamestartswith1", 1, id="atoms_name__startswith"),
+            param("atoms", "name__endswith", "endswith0", 1, id="atoms_name__endswith"),
+            param("atoms", "name__regex", "nameregex[0-1]", 2, id="atoms_name__regex"),
+            param("atoms", "description", "Test atom 1", 1, id="atoms_description"),
+            param("atoms", "description__contains", "Test atom", 3, id="atoms_description__contains"),
+            param("atoms", "description__regex", "Test atom [0-1]", 2, id="atoms_description__regex"),
+        ],
+    )
     def test_filtering_for_hostpolicy(self, endpoint: str, query_key: str, target: str, expected_hits: str) -> None:
         """Test filtering on hostpolicy."""
 
@@ -217,7 +212,7 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
 
         roles, atoms, labels = create_roles(endpoint, hosts, atoms, labels)
 
-        response = self.client.get(f"/api/v1/hostpolicy/{endpoint}/?{query_key}={target}")        
+        response = self.client.get(f"/api/v1/hostpolicy/{endpoint}/?{query_key}={target}")
         self.assertEqual(response.status_code, 200, msg=f"{msg_prefix} {response.content}")
         data = response.json()
         self.assertEqual(data["count"], expected_hits, msg=f"{msg_prefix} {data}")
@@ -233,9 +228,8 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
 
         for host in hosts:
             with self.subTest(host=host):
-                id = host.id # type: ignore
+                id = host.id  # type: ignore
                 msg_prefix = f"hosts : id -> {id} => "
-
                 response = self.client.get(f"/api/v1/hosts/?id={id}")
                 self.assertEqual(response.status_code, 200, msg=f"{msg_prefix} {response.content}")
                 data = response.json()

--- a/mreg/api/v1/tests/test_filtering.py
+++ b/mreg/api/v1/tests/test_filtering.py
@@ -1,12 +1,51 @@
 from typing import List
+from itertools import chain
 
 from unittest_parametrize import ParametrizedTestCase, param, parametrize
 
-from mreg.models.host import Host
+from mreg.models.host import Host, Ipaddress
 from mreg.models.resource_records import Cname
 
 from .tests import MregAPITestCase
 
+def create_hosts(name: str, count: int) -> List[Host]:
+    """Create hosts."""
+
+    hosts: List[Host] = []
+    for i in range(count):
+        hosts.append(Host.objects.create(
+            name=f"{name}{i}.example.com".replace("_", ""),
+            contact="admin@example.com",
+            ttl=3600,
+            comment="Test host",
+        ))
+
+    return hosts
+
+def create_cnames(hosts: List[Host]) -> List[Cname]:
+    """Create cnames."""
+
+    cnames: List[Cname] = []
+    for host in hosts:
+        cnames.append(Cname.objects.create(
+            host=host,
+            name=f"cname.{host.name}",
+            ttl=3600,
+        ))
+
+    return cnames
+
+def create_ipaddresses(hosts: List[Host]) -> List[Ipaddress]:
+    """Create ipaddresses."""
+
+    ipaddresses: List[Ipaddress] = []
+    for i, host in enumerate(hosts):
+        ipaddresses.append(Ipaddress.objects.create(
+            host=host,
+            ipaddress=f"10.0.0.{i}",
+        ))
+
+    return ipaddresses
 
 class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
     """Test filtering."""
@@ -19,7 +58,28 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
     @parametrize(
         ("endpoint", "query_key", "target", "expected_hits"),
         [
+            # Direct host filtering
             param("hosts", "name", "hostsname0.example.com", 1, id="hosts_name"),
+            param("hosts", "name__contains", "namecontains1", 1, id="hosts_name__contains"),
+            param("hosts", "name__icontains", "nameicontains2", 1, id="hosts_name__icontains"),
+            param("hosts", "name__iexact", "nameiexact2.example.com", 1, id="hosts_name__iexact"),
+            param("hosts", "name__startswith", "namestartswith1", 1, id="hosts_name__startswith"),
+            param("hosts", "name__endswith", "endswith0.example.com", 1, id="hosts_name__endswith"),
+            param("hosts", "name_regex", "nameregex[0-9].example.com", 3, id="hosts_name__regex"),
+
+            # Reverse through Ipaddress
+            param("hosts", "ipaddresses__ipaddress", "10.0.0.1", 1, id="hosts_ipaddresses__ipaddress"),
+
+            # Reverse through Cname
+            param("hosts", "cnames__name", "cname.hostscnamesname0.example.com", 1, id="hosts_cnames__name"),
+            param("hosts", "cnames__name__regex", "cname.*regex[0-1].example.com", 2, id="host_cnames__regex"),
+            param("hosts", "cnames__name__endswith", "with0.example.com", 1, id="hosts_cnames__endswith"),
+
+            # Indirectly through Ipaddress
+            param("ipaddresses", "host__name", "ipaddresseshostname0.example.com", 1, id="ipaddresses_host__name"),
+            param("ipaddresses", "host__name__contains", "contains1", 1, id="ipaddresses_host__contains"),
+
+            # Indirectly through Cname
             param("cnames", "host__name", "cnameshostname1.example.com", 1, id="cnames_host__name"),
             param("cnames", "host__name__icontains", "cnameshostnameicontains", 3, id="cnames_host__icontains"),
             param("cnames", "host__name__iexact", "cnameshostnameiexact1.example.com", 1, id="cnames_host__iexact"),
@@ -34,31 +94,16 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
         generate_count = 3
         msg_prefix = f"{endpoint} : {query_key} -> {target} => "
 
-        hosts: List[Host] = []
-        cnames: List[Cname] = []
-        for i in range(generate_count):
-            hostname = f"{endpoint}{query_key}{i}.example.com".replace("_", "")
-            hosts.append(
-                Host.objects.create(
-                    name=hostname,
-                    contact="admin@example.com",
-                    ttl=3600,
-                    comment="Test host",
-                )
-            )
+        hosts = create_hosts(f"{endpoint}{query_key}", generate_count)
+        cnames = create_cnames(hosts)
+        ipadresses = create_ipaddresses(hosts)
 
-        for i in range(generate_count):
-            cname = f"cname.{endpoint}{query_key}{i}.example.com".replace("_", "")
-            cnames.append(Cname.objects.create(host=hosts[i], name=cname, ttl=3600))
-
-        hostname = hosts[0].name
         response = self.client.get(f"/api/v1/{endpoint}/?{query_key}={target}")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200, msg=f"{msg_prefix} {response.content}")
         data = response.json()
         self.assertEqual(data["count"], expected_hits, msg=f"{msg_prefix} {data}")
 
-        for host in hosts:
-            host.delete()
+        for obj in chain(ipadresses, cnames, hosts):
+            obj.delete()
 
-        for cname in cnames:
-            cname.delete()
+

--- a/mreg/api/v1/tests/test_filtering.py
+++ b/mreg/api/v1/tests/test_filtering.py
@@ -1,51 +1,122 @@
-from typing import List
+from typing import List, Tuple
 from itertools import chain
 
 from unittest_parametrize import ParametrizedTestCase, param, parametrize
 
+from hostpolicy.models import HostPolicyAtom, HostPolicyRole
+from mreg.models.base import Label
 from mreg.models.host import Host, Ipaddress
 from mreg.models.resource_records import Cname
 
 from .tests import MregAPITestCase
+
 
 def create_hosts(name: str, count: int) -> List[Host]:
     """Create hosts."""
 
     hosts: List[Host] = []
     for i in range(count):
-        hosts.append(Host.objects.create(
-            name=f"{name}{i}.example.com".replace("_", ""),
-            contact="admin@example.com",
-            ttl=3600,
-            comment="Test host",
-        ))
+        hosts.append(
+            Host.objects.create(
+                name=f"{name}{i}.example.com".replace("_", ""),
+                contact="admin@example.com",
+                ttl=3600,
+                comment="Test host",
+            )
+        )
 
     return hosts
+
 
 def create_cnames(hosts: List[Host]) -> List[Cname]:
     """Create cnames."""
 
     cnames: List[Cname] = []
     for host in hosts:
-        cnames.append(Cname.objects.create(
-            host=host,
-            name=f"cname.{host.name}",
-            ttl=3600,
-        ))
+        cnames.append(
+            Cname.objects.create(
+                host=host,
+                name=f"cname.{host.name}",
+                ttl=3600,
+            )
+        )
 
     return cnames
+
 
 def create_ipaddresses(hosts: List[Host]) -> List[Ipaddress]:
     """Create ipaddresses."""
 
     ipaddresses: List[Ipaddress] = []
     for i, host in enumerate(hosts):
-        ipaddresses.append(Ipaddress.objects.create(
-            host=host,
-            ipaddress=f"10.0.0.{i}",
-        ))
+        ipaddresses.append(
+            Ipaddress.objects.create(
+                host=host,
+                ipaddress=f"10.0.0.{i}",
+            )
+        )
 
     return ipaddresses
+
+def create_labels(name: str, count: int) -> List[Label]:
+    """Create labels."""
+
+    labels: List[Label] = []
+    for i in range(count):
+        labels.append(
+            Label.objects.create(
+                name=f"{name}{i}".replace("_", ""),
+                description="Test label",
+            )
+        )
+
+    return labels
+
+def create_atoms(name: str, count: int) -> List[HostPolicyAtom]:
+    """Create atoms."""
+
+    atoms: List[HostPolicyAtom] = []
+    for i in range(count):
+        atoms.append(
+            HostPolicyAtom.objects.create(
+                name=f"{name}{i}".replace("_", ""),
+                description=f"Test atom {i}",
+            )
+        )
+
+    return atoms
+
+
+def create_roles(
+    name: str, hosts: List[Host], atoms: List[HostPolicyAtom], labels: List[Label]
+) -> Tuple[List[HostPolicyRole], List[HostPolicyAtom], List[Label]]:
+    """Create roles."""
+
+    if not atoms:
+        atoms = create_atoms(f"{name}atom", len(hosts))
+
+    if not labels:
+        labels = create_labels(f"{name}label", len(hosts))
+
+    if len(hosts) != len(atoms) or len(hosts) != len(labels):
+        raise ValueError("Hosts, Atoms, and Labels must be the same length.")
+
+    roles: List[HostPolicyRole] = []
+
+    for i, h in enumerate(hosts):
+        policy = HostPolicyRole.objects.create(
+                name=f"{name}host{i}".replace("_", ""),
+                description="Test role")
+        
+        policy.hosts.add(h)
+        policy.labels.add(labels[i])
+        policy.atoms.add(atoms[i])
+
+        roles.append(policy)
+        
+
+    return (roles, atoms, labels)
+
 
 class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
     """Test filtering."""
@@ -55,30 +126,24 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
     # NOTE: The generated hostnames are UNIQUE across every test case!
     # The format is: f"{endpoint}{query_key}{i}.example.com".replace("_", "")
     # where i is the index of the hostname (and we make three for each test).
-    @parametrize(
-        ("endpoint", "query_key", "target", "expected_hits"),
-        [
+    @parametrize(("endpoint", "query_key", "target", "expected_hits"), [
             # Direct host filtering
             param("hosts", "name", "hostsname0.example.com", 1, id="hosts_name"),
             param("hosts", "name__contains", "namecontains1", 1, id="hosts_name__contains"),
             param("hosts", "name__icontains", "nameicontains2", 1, id="hosts_name__icontains"),
-            param("hosts", "name__iexact", "nameiexact2.example.com", 1, id="hosts_name__iexact"),
-            param("hosts", "name__startswith", "namestartswith1", 1, id="hosts_name__startswith"),
+            param("hosts", "name__iexact", "hostsnameiexact2.example.com", 1, id="hosts_name__iexact"),
+            param("hosts", "name__startswith", "hostsnamestartswith1", 1, id="hosts_name__startswith"),
             param("hosts", "name__endswith", "endswith0.example.com", 1, id="hosts_name__endswith"),
             param("hosts", "name_regex", "nameregex[0-9].example.com", 3, id="hosts_name__regex"),
-
             # Reverse through Ipaddress
             param("hosts", "ipaddresses__ipaddress", "10.0.0.1", 1, id="hosts_ipaddresses__ipaddress"),
-
             # Reverse through Cname
             param("hosts", "cnames__name", "cname.hostscnamesname0.example.com", 1, id="hosts_cnames__name"),
             param("hosts", "cnames__name__regex", "cname.*regex[0-1].example.com", 2, id="host_cnames__regex"),
             param("hosts", "cnames__name__endswith", "with0.example.com", 1, id="hosts_cnames__endswith"),
-
             # Indirectly through Ipaddress
             param("ipaddresses", "host__name", "ipaddresseshostname0.example.com", 1, id="ipaddresses_host__name"),
             param("ipaddresses", "host__name__contains", "contains1", 1, id="ipaddresses_host__contains"),
-
             # Indirectly through Cname
             param("cnames", "host__name", "cnameshostname1.example.com", 1, id="cnames_host__name"),
             param("cnames", "host__name__icontains", "cnameshostnameicontains", 3, id="cnames_host__icontains"),
@@ -106,4 +171,56 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
         for obj in chain(ipadresses, cnames, hosts):
             obj.delete()
 
+    @parametrize(("endpoint", "query_key", "target", "expected_hits"), [
+        param("roles", "name", "roleshost0", 1, id="roles_name"),
+        param("roles", "name__contains", "roleshost1", 1, id="roles_name__contains"),
+        param("roles", "name__icontains", "roleshost2", 1, id="roles_name__icontains"),
+        param("roles", "name__iexact", "roleshost2", 1, id="roles_name__iexact"),
+        param("roles", "name__startswith", "roleshost1", 1, id="roles_name__startswith"),
+        param("roles", "name__endswith", "host1", 1, id="roles_name__endswith"),
+        param("roles", "name__regex", "roleshost[0-1]", 2, id="roles_name__regex"),
 
+        param("roles", "atoms__name__exact", "rolesatomsnameexact1", 1, id="roles_atoms__name__exact"),
+        param("roles", "atoms__name__contains", "namecontains1", 1, id="roles_atoms__name__contains"),
+        param("roles", "atoms__name__regex", "nameregex[0-1]", 2, id="roles_atoms__name__regex"),
+
+        param("roles", "hosts__name__exact", "roleshostsnameexact1.example.com", 1, id="roles_hosts__name__exact"),
+        param("roles", "hosts__name__contains", "namecontains1", 1, id="roles_hosts__name__contains"),
+        param("roles", "hosts__name__regex", "nameregex[0-1].example.com", 2, id="roles_hosts__name__regex"),
+
+        param("roles", "labels__name__exact", "roleslabelsnameexact1", 1, id="roles_labels__name__exact"),
+        param("roles", "labels__name__contains", "namecontains1", 1, id="roles_labels__name__contains"),
+        param("roles", "labels__name__regex", "nameregex[0-1]", 2, id="roles_labels__name__regex"),
+
+        param("atoms", "name", "atomsname0", 1, id="atoms_name"),
+        param("atoms", "name__contains", "namecontains1", 1, id="atoms_name__contains"),
+        param("atoms", "name__icontains", "nameicontains2", 1, id="atoms_name__icontains"),
+        param("atoms", "name__iexact", "atomsnameiexact2", 1, id="atoms_name__iexact"),
+        param("atoms", "name__startswith", "atomsnamestartswith1", 1, id="atoms_name__startswith"),
+        param("atoms", "name__endswith", "endswith0", 1, id="atoms_name__endswith"),
+        param("atoms", "name__regex", "nameregex[0-1]", 2, id="atoms_name__regex"),
+
+        param("atoms", "description", "Test atom 1", 1, id="atoms_description"),
+        param("atoms", "description__contains", "Test atom", 3, id="atoms_description__contains"),
+        param("atoms", "description__regex", "Test atom [0-1]", 2, id="atoms_description__regex"),
+
+    ])
+    def test_filtering_for_hostpolicy(self, endpoint: str, query_key: str, target: str, expected_hits: str) -> None:
+        """Test filtering on hostpolicy."""
+
+        generate_count = 3
+        msg_prefix = f"{endpoint} : {query_key} -> {target} => "
+
+        hosts = create_hosts(f"{endpoint}{query_key}", generate_count)
+        atoms = create_atoms(f"{endpoint}{query_key}", generate_count)
+        labels = create_labels(f"{endpoint}{query_key}", generate_count)
+
+        roles, atoms, labels = create_roles(endpoint, hosts, atoms, labels)
+
+        response = self.client.get(f"/api/v1/hostpolicy/{endpoint}/?{query_key}={target}")        
+        self.assertEqual(response.status_code, 200, msg=f"{msg_prefix} {response.content}")
+        data = response.json()
+        self.assertEqual(data["count"], expected_hits, msg=f"{msg_prefix} {data}")
+
+        for obj in chain(roles, atoms, labels, hosts):
+            obj.delete()

--- a/mreg/api/v1/tests/test_filtering.py
+++ b/mreg/api/v1/tests/test_filtering.py
@@ -1,0 +1,67 @@
+
+from typing import List
+
+from mreg.models.host import Host
+from mreg.models.resource_records import Cname
+
+from .tests import MregAPITestCase
+
+from unittest_parametrize import param
+from unittest_parametrize import parametrize
+from unittest_parametrize import ParametrizedTestCase
+
+
+class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
+    """Test filtering."""
+
+    # endpoint, query_key, target, expected_hits
+    #
+    # NOTE: The generated hostnames are UNIQUE across every test case!
+    # The format is: f"{endpoint}{query_key}{i}.example.com".replace("_", "")
+    # where i is the index of the hostname (and we make three for each test).
+    @parametrize(
+        ("endpoint", "query_key", "target", "expected_hits"),
+        [
+            param("hosts", "name", "hostsname0.example.com", 1, id="hosts_name"),
+            param("cnames", "host__name",  "cnameshostname1.example.com", 1, id="cnames_host__name"),
+            param("cnames", "host__name__icontains",  "cnameshostnameicontains", 3, id="cnames_host__icontains"),
+        ],
+
+    )
+    def test_filtering_for_host(self, endpoint: str, query_key: str, target: str, expected_hits: str) -> None:
+        """Test filtering on host."""
+
+        generate_count = 3
+        msg_prefix = f"{endpoint} : {query_key} -> {target} => "
+
+        hosts: List[Host] = []
+        cnames: List[Cname] = []
+        for i in range(generate_count):
+            hostname = f"{endpoint}{query_key}{i}.example.com".replace("_", "")
+            hosts.append(Host.objects.create(
+                name=hostname,
+                contact="admin@example.com",
+                ttl=3600,
+                comment="Test host",
+            ))
+        
+        for i in range(generate_count):
+            cname = f"cname.{endpoint}{query_key}{i}.example.com".replace("_", "")
+            cnames.append(Cname.objects.create(
+                host=hosts[i],
+                name=cname,
+                ttl=3600
+            ))
+
+        hostname = hosts[0].name
+        response = self.client.get(f"/api/v1/{endpoint}/?{query_key}={target}")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["count"], expected_hits, msg=f"{msg_prefix} {data}")
+
+        for host in hosts:
+            host.delete()
+
+        for cname in cnames:
+            cname.delete()
+

--- a/mreg/api/v1/tests/test_filtering.py
+++ b/mreg/api/v1/tests/test_filtering.py
@@ -1,4 +1,3 @@
-
 from typing import List
 
 from unittest_parametrize import ParametrizedTestCase, param, parametrize
@@ -21,14 +20,13 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
         ("endpoint", "query_key", "target", "expected_hits"),
         [
             param("hosts", "name", "hostsname0.example.com", 1, id="hosts_name"),
-            param("cnames", "host__name",  "cnameshostname1.example.com", 1, id="cnames_host__name"),
-            param("cnames", "host__name__icontains",  "cnameshostnameicontains", 3, id="cnames_host__icontains"),
-            param("cnames", "host__name__iexact",  "cnameshostnameiexact1.example.com", 1, id="cnames_host__iexact"),
-            param("cnames", "host__name__startswith",  "cnameshostnamestartswith", 3, id="cnames_host__startswith"),
-            param("cnames", "host__name__endswith",  "endswith2.example.com", 1, id="cnames_host__endswith"),
-            param("cnames", "host__name__regex",  "cnameshostnameregex[0-9]", 3, id="cnames_host__regex"),
+            param("cnames", "host__name", "cnameshostname1.example.com", 1, id="cnames_host__name"),
+            param("cnames", "host__name__icontains", "cnameshostnameicontains", 3, id="cnames_host__icontains"),
+            param("cnames", "host__name__iexact", "cnameshostnameiexact1.example.com", 1, id="cnames_host__iexact"),
+            param("cnames", "host__name__startswith", "cnameshostnamestartswith", 3, id="cnames_host__startswith"),
+            param("cnames", "host__name__endswith", "endswith2.example.com", 1, id="cnames_host__endswith"),
+            param("cnames", "host__name__regex", "cnameshostnameregex[0-9]", 3, id="cnames_host__regex"),
         ],
-
     )
     def test_filtering_for_host(self, endpoint: str, query_key: str, target: str, expected_hits: str) -> None:
         """Test filtering on host."""
@@ -40,20 +38,18 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
         cnames: List[Cname] = []
         for i in range(generate_count):
             hostname = f"{endpoint}{query_key}{i}.example.com".replace("_", "")
-            hosts.append(Host.objects.create(
-                name=hostname,
-                contact="admin@example.com",
-                ttl=3600,
-                comment="Test host",
-            ))
-        
+            hosts.append(
+                Host.objects.create(
+                    name=hostname,
+                    contact="admin@example.com",
+                    ttl=3600,
+                    comment="Test host",
+                )
+            )
+
         for i in range(generate_count):
             cname = f"cname.{endpoint}{query_key}{i}.example.com".replace("_", "")
-            cnames.append(Cname.objects.create(
-                host=hosts[i],
-                name=cname,
-                ttl=3600
-            ))
+            cnames.append(Cname.objects.create(host=hosts[i], name=cname, ttl=3600))
 
         hostname = hosts[0].name
         response = self.client.get(f"/api/v1/{endpoint}/?{query_key}={target}")
@@ -66,4 +62,3 @@ class FilterTestCase(ParametrizedTestCase, MregAPITestCase):
 
         for cname in cnames:
             cname.delete()
-

--- a/mreg/api/v1/tests/tests_bacnet.py
+++ b/mreg/api/v1/tests/tests_bacnet.py
@@ -10,7 +10,7 @@ class BACnetIDTest(MregAPITestCase):
     basepath = '/api/v1/bacnet/ids/'
 
     def basejoin(self, path):
-        if type(path) != 'str':
+        if not isinstance(path, str):
             path = str(path)
         return self.basepath + path
 

--- a/mreg/middleware/logging_http.py
+++ b/mreg/middleware/logging_http.py
@@ -106,6 +106,7 @@ class LoggingMiddleware:
             remote_ip=remote_ip,
             proxy_ip=proxy_ip,
             path=request.path_info,
+            query_string=request.META.get("QUERY_STRING"),
             request_size=request_size,
             content=self._get_body(request),
         ).info("request")
@@ -150,6 +151,7 @@ class LoggingMiddleware:
             status_code=status_code,
             status_label=status_label,
             path=request.path_info,
+            query_string=request.META.get("QUERY_STRING"),  
             content=content,
             **extra_data,
             run_time_ms=round(run_time_ms, 2),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-[tool.ruff]
+[tool.lint.ruff]
 # https://beta.ruff.rs/docs/rules/
 select = ["E", "F"]
 line-length = 119

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,3 @@
-[tool.lint.ruff]
-# https://beta.ruff.rs/docs/rules/
-select = ["E", "F"]
-line-length = 119
-exclude = [
-    "mreg/migrations/",
-    "hostpolicy/migrations/",
-    ".tox",
-]
-
 [project]
 name = "mreg"
 version = "0.0.1"
@@ -22,3 +12,14 @@ requires = [
 
 [tool.setuptools]
 py-modules = ["mreg", "mregsite", "hostpolicy"] 
+
+[tool.ruff]
+# https://beta.ruff.rs/docs/rules/
+select = ["E", "F"]
+line-length = 119
+exclude = [
+    "mreg/migrations/",
+    "hostpolicy/migrations/",
+    ".tox",
+]
+

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -16,6 +16,7 @@ tzdata==2024.1
 tox
 pytest
 pytest-django
+unittest_parametrize
 
 # These are currently not used, but should be...
 pylint

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,14 +3,14 @@ djangorestframework==3.14.0
 django-auth-ldap==4.8.0
 django-logging-json==1.15
 django-netfields==1.3.2
-django-filter==24.2
-structlog==24.1.0
+django-filter==24.3
+structlog==24.4.0
 rich==13.7.1
 gunicorn==22.0.0
 idna==3.7
 psycopg2-binary==2.9.9
 pika==1.3.2
-sentry-sdk==2.3.1
+sentry-sdk==2.12.0
 tzdata==2024.1
 # Testing framwork
 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
-Django==5.0.6
+Django==5.0.8
 djangorestframework==3.14.0
 django-auth-ldap==4.8.0
 django-netfields==1.3.2
-django-filter==24.2
-structlog==24.1.0
+django-filter==24.3
+structlog==24.4.0
 rich==13.7.1
 gunicorn==22.0.0
 idna==3.7
 psycopg2-binary==2.9.9
 pika==1.3.2
-sentry-sdk==2.3.1
+sentry-sdk==2.12.0
 tzdata==2024.1
 # For OpenAPI schema generation.
 uritemplate


### PR DESCRIPTION
Manually sets the appropriate filters for most filter sets. A number of attempts at automating the code led nowhere good, so this is where we are. 

A lot of this may be cleaned up when DRF 3.15.3 is released as we can bump DRF to 3.15 that officially supports Django5. We are stuck on 3.14.0 due to https://github.com/encode/django-rest-framework/issues/9358 but https://github.com/encode/django-rest-framework/pull/9483 has been merged an hopefully makes 3.15.3.