### PR TITLE
Remove openapi building and testing.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,14 +67,14 @@ jobs:
           MREG_DB_PASSWORD: postgres
       - name: Check migrations
         run: python manage.py makemigrations --check
-      - name: Export OpenAPI schema
-        run: python manage.py generateschema > openapi.yml
-      - name: Upload OpenAPI schema
-        if: matrix.python-version == '3.10'
-        uses: actions/upload-artifact@v3
-        with:
-          name: openapi.yml
-          path: openapi.yml
+#      - name: Export OpenAPI schema
+#        run: python manage.py generateschema > openapi.yml
+#      - name: Upload OpenAPI schema
+#        if: matrix.python-version == '3.10'
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: openapi.yml
+#          path: openapi.yml
       - name: Upload coverage
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
  - Even if the tests pass (which they won't until DRF 3.15.3 is released and used), the results are broken due to duplicate identifiers for endpoints.