### PR TITLE
Log user agent.

### DIFF
--- a/mreg/middleware/logging_http.py
+++ b/mreg/middleware/logging_http.py
@@ -41,7 +41,7 @@ class LoggingMiddleware:
         :param request: The incoming request.
         :return: A response object
         """
-        start_time = time.time()
+        start_time = int(time.time())
 
         self.log_request(request)
         response = self.get_response(request)
@@ -98,6 +98,8 @@ class LoggingMiddleware:
         else:
             proxy_ip = ""
 
+        user_agent = self._get_request_header(request, "user-agent", "HTTP_USER_AGENT")
+
         # Size of request
         request_size = len(request.body)
 
@@ -105,6 +107,7 @@ class LoggingMiddleware:
             method=request.method,
             remote_ip=remote_ip,
             proxy_ip=proxy_ip,
+            user_agent=user_agent,
             path=request.path_info,
             query_string=request.META.get("QUERY_STRING"),
             request_size=request_size,


### PR DESCRIPTION
````
2024-11-20T14:55:37.361509Z [info     ]  • request          request_id=090...e47 method=GET remote_ip=127.0.0.1 proxy_ip= user_agent=mreg-cli-1.1.1.dev4+g8d3a96e path=/api/v1/hosts/ query_string=page_size=1 request_size=0 content= lineno=115 func_name=log_request filename=logging_http.py
2024-11-20T14:55:37.363096Z [warning  ]  • response         request_id=090...e47 user= method=GET status_code=401 status_label=Unauthorized path=/api/v1/hosts/ query_string=page_size=1 content={"detail":"Authentication credentials were not provided."} run_time_ms=362.98 lineno=161 func_name=log_response filename=logging_http.py
````