### PR TITLE
Meta endpoint expansion

### DIFF
--- a/mreg/api/urls.py
+++ b/mreg/api/urls.py
@@ -5,6 +5,7 @@ from . import views
 urlpatterns = [
     path('token-logout/', views.TokenLogout.as_view()),
     path('token-auth/', views.ObtainExpiringAuthToken.as_view()),
+    path('meta/version', views.MregVersion.as_view()),
     path('meta/heartbeat', views.MetaHeartbeat.as_view()),
-    path('meta/versions', views.MetaVersions.as_view()),
+    path('meta/libraries', views.MetaVersions.as_view()),
 ]

--- a/mreg/api/urls.py
+++ b/mreg/api/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path('token-logout/', views.TokenLogout.as_view()),
     path('token-auth/', views.ObtainExpiringAuthToken.as_view()),
     path('token-is-valid/', views.TokenIsValid.as_view()),
+    path('meta/user', views.UserInfo.as_view()),
     path('meta/version', views.MregVersion.as_view()),
     path('meta/libraries', views.MetaVersions.as_view()),
     path('meta/heartbeat', views.MetaHeartbeat.as_view()),

--- a/mreg/api/urls.py
+++ b/mreg/api/urls.py
@@ -5,7 +5,8 @@ from . import views
 urlpatterns = [
     path('token-logout/', views.TokenLogout.as_view()),
     path('token-auth/', views.ObtainExpiringAuthToken.as_view()),
+    path('token-is-valid/', views.TokenIsValid.as_view()),
     path('meta/version', views.MregVersion.as_view()),
-    path('meta/heartbeat', views.MetaHeartbeat.as_view()),
     path('meta/libraries', views.MetaVersions.as_view()),
+    path('meta/heartbeat', views.MetaHeartbeat.as_view()),
 ]

--- a/mreg/api/v1/tests/tests.py
+++ b/mreg/api/v1/tests/tests.py
@@ -307,6 +307,22 @@ class APIMetaTestCase(MregAPITestCase):
         response = self.assert_get("/api/meta/version")
         self.assertTrue('version' in response.data)
 
+    def test_meta_user_info_self_200_ok(self):
+        self.client = self.get_token_client(superuser=False)
+        response = self.assert_get("/api/meta/user")
+        self.assertTrue('username' in response.data)
+    
+    def test_meta_user_info_admin_other_target_200_ok(self):
+        response = self.assert_get("/api/meta/user?username=superuser")
+        self.assertTrue('username' in response.data)
+
+    def test_meta_user_info_user_other_target_403_forbidden(self):
+        self.client = self.get_token_client(superuser=False)
+        self.assert_get_and_403("/api/meta/user?username=superuser")
+
+    def test_meta_user_info_user_not_found_404_not_found(self):
+        self.assert_get_and_404("/api/meta/user?username=nonexistent")
+
     def test_meta_heartbeat_user_200_ok(self):
         self.client = self.get_token_client(superuser=False)
         response = self.assert_get("/api/meta/heartbeat")

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -12,8 +12,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from django_auth_ldap import __version__ as ldap_version
+from django_filters import __version__ as filters_version
+from gunicorn import __version__ as gunicorn_version
+from sentry_sdk import VERSION as sentry_sdk_version
+from psycopg2 import __libpq_version__ as libpq_version
+
 from mreg.api.permissions import IsSuperOrNetworkAdminMember
 from mreg.models.base import ExpiringToken
+from mreg.__about__ import __version__ as mreg_version
 
 start_time = int(time.time())
 
@@ -63,15 +70,30 @@ class TokenLogout(APIView):
         return Response(status=status.HTTP_200_OK)
 
 
+class MregVersion(APIView):
+    
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request: Request):
+        data = {
+            "version": mreg_version,
+        }
+        return Response(status=status.HTTP_200_OK, data=data)
+
 class MetaVersions(APIView):
 
     permission_classes = (IsSuperOrNetworkAdminMember,)
 
     def get(self, request: Request):
         data = {
-            "django_version": django.get_version(),
-            "rest_framework_version": res_version,
-            "python_version": platform.python_version(),
+            "python": platform.python_version(),
+            "django": django.get_version(),
+            "djangorestframework": res_version,
+            "django_auth_ldap": ldap_version,
+            "django_filters": filters_version,
+            "gunicorn": gunicorn_version,
+            "sentry_sdk": sentry_sdk_version,
+            "libpq": libpq_version,
         }
         return Response(status=status.HTTP_200_OK, data=data)
 

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -3,11 +3,12 @@ import time
 from typing import Any, cast
 
 import django
+from django.conf import settings
 import structlog
 
 from rest_framework import serializers, status
 from rest_framework.authtoken.views import ObtainAuthToken
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.exceptions import AuthenticationFailed, PermissionDenied, NotFound
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,6 +19,8 @@ from psycopg2 import __libpq_version__ as libpq_version
 
 from mreg.api.permissions import IsSuperOrNetworkAdminMember
 from mreg.models.base import ExpiringToken
+from mreg.models.auth import User
+from mreg.models.network import NetGroupRegexPermission
 from mreg.__about__ import __version__ as mreg_version
 
 logger = structlog.getLogger(__name__)
@@ -92,6 +95,78 @@ class TokenIsValid(APIView):
     def get(self, request: Request):
         return Response(status=status.HTTP_200_OK)  
 
+###
+### User infomation views
+####
+
+class UserInfo(APIView):
+
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request: Request):
+        # Identify the requesting user
+        user = request.user
+        groups = user.groups.all()
+        is_mreg_superuser = settings.SUPERUSER_GROUP in [group.name for group in groups]
+        is_mreg_admin = settings.ADMINUSER_GROUP in [group.name for group in groups]
+        is_mreg_group_admin = settings.GROUPADMINUSER_GROUP in [group.name for group in groups]
+        is_mreg_network_admin = settings.NETWORK_ADMIN_GROUP in [group.name for group in groups]
+        is_mreg_hostpolicy_admin = settings.HOSTPOLICYADMIN_GROUP in [group.name for group in groups]
+        is_mreg_dns_wildcard_admin = settings.DNS_WILDCARD_GROUP in [group.name for group in groups]
+        is_mreg_dns_underscore_admin = settings.DNS_UNDERSCORE_GROUP in [group.name for group in groups]
+
+        # Determine target user (default is the requesting user)
+        username = request.query_params.get("username")
+        target_user = user
+
+        if username:
+            # Only allow access to other user data if the requester is an mreg superuser
+            if not is_mreg_superuser or is_mreg_admin or is_mreg_group_admin or is_mreg_network_admin:
+                raise PermissionDenied("You do not have permission to view other users' details.")
+            try:
+                target_user = User.objects.get(username=username)
+            except User.DoesNotExist:
+                raise NotFound(f"User with username '{username}' not found.")
+
+        # Gather target user's information
+        target_groups = target_user.groups.all()
+        target_permissions = NetGroupRegexPermission.objects.filter(
+            group__in=[group.name for group in target_groups]
+        )
+
+        data = {
+            "username": target_user.username,
+            "django_status": {
+                "superuser": target_user.is_superuser,
+                "staff": target_user.is_staff,
+                "active": target_user.is_active,
+            },
+            "mreg_status": {
+                "superuser": is_mreg_superuser,
+                "admin": is_mreg_admin,
+                "group_admin": is_mreg_group_admin,
+                "network_admin": is_mreg_network_admin,
+                "hostpolicy_admin": is_mreg_hostpolicy_admin,
+                "dns_wildcard_admin": is_mreg_dns_wildcard_admin,
+                "underscore_admin": is_mreg_dns_underscore_admin
+            },
+            "groups": [group.name for group in target_groups],
+            "permissions": [
+                {
+                    "group": permission.group,
+                    "range": permission.range,
+                    "regex": permission.regex,
+                    "labels": [label.name for label in permission.labels.all()],
+                }
+                for permission in target_permissions
+            ],
+        }
+
+        return Response(status=status.HTTP_200_OK, data=data)
+    
+###
+### Introspection views
+###
 class MregVersion(APIView):
     
     permission_classes = (IsAuthenticated,)

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -106,14 +106,11 @@ class UserInfo(APIView):
     def get(self, request: Request):
         # Identify the requesting user
         user = request.user
-        groups = user.groups.all()
-        is_mreg_superuser = settings.SUPERUSER_GROUP in [group.name for group in groups]
-        is_mreg_admin = settings.ADMINUSER_GROUP in [group.name for group in groups]
-        is_mreg_group_admin = settings.GROUPADMINUSER_GROUP in [group.name for group in groups]
-        is_mreg_network_admin = settings.NETWORK_ADMIN_GROUP in [group.name for group in groups]
-        is_mreg_hostpolicy_admin = settings.HOSTPOLICYADMIN_GROUP in [group.name for group in groups]
-        is_mreg_dns_wildcard_admin = settings.DNS_WILDCARD_GROUP in [group.name for group in groups]
-        is_mreg_dns_underscore_admin = settings.DNS_UNDERSCORE_GROUP in [group.name for group in groups]
+        req_groups = user.groups.all()
+        req_is_mreg_superuser = settings.SUPERUSER_GROUP in [group.name for group in req_groups]
+        req_is_mreg_admin = settings.ADMINUSER_GROUP in [group.name for group in req_groups]
+        req_is_mreg_group_admin = settings.GROUPADMINUSER_GROUP in [group.name for group in req_groups]
+        req_is_mreg_network_admin = settings.NETWORK_ADMIN_GROUP in [group.name for group in req_groups]
 
         # Determine target user (default is the requesting user)
         username = request.query_params.get("username")
@@ -121,7 +118,7 @@ class UserInfo(APIView):
 
         if username:
             # Only allow access to other user data if the requester is an mreg superuser
-            if not is_mreg_superuser or is_mreg_admin or is_mreg_group_admin or is_mreg_network_admin:
+            if not req_is_mreg_superuser or req_is_mreg_admin or req_is_mreg_group_admin or req_is_mreg_network_admin:
                 raise PermissionDenied("You do not have permission to view other users' details.")
             try:
                 target_user = User.objects.get(username=username)
@@ -133,6 +130,14 @@ class UserInfo(APIView):
         target_permissions = NetGroupRegexPermission.objects.filter(
             group__in=[group.name for group in target_groups]
         )
+        
+        is_mreg_superuser = settings.SUPERUSER_GROUP in [group.name for group in target_groups]
+        is_mreg_admin = settings.ADMINUSER_GROUP in [group.name for group in target_groups]
+        is_mreg_group_admin = settings.GROUPADMINUSER_GROUP in [group.name for group in target_groups]
+        is_mreg_network_admin = settings.NETWORK_ADMIN_GROUP in [group.name for group in target_groups]
+        is_mreg_hostpolicy_admin = settings.HOSTPOLICYADMIN_GROUP in [group.name for group in target_groups]
+        is_mreg_dns_wildcard_admin = settings.DNS_WILDCARD_GROUP in [group.name for group in target_groups]
+        is_mreg_dns_underscore_admin = settings.DNS_UNDERSCORE_GROUP in [group.name for group in target_groups]
 
         data = {
             "username": target_user.username,

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -85,6 +85,12 @@ class TokenLogout(APIView):
         request.user.delete()
         return Response(status=status.HTTP_200_OK)
 
+class TokenIsValid(APIView):
+
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request: Request):
+        return Response(status=status.HTTP_200_OK)  
 
 class MregVersion(APIView):
     

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -40,7 +40,7 @@ LIBRARIES_TO_REPORT = [
     "sentry-sdk",
     "structlog",
     "rich",
-    "psycopg2-binary","idontexist"
+    "psycopg2-binary",
 ]
 
 

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -116,7 +116,7 @@ class UserInfo(APIView):
         username = request.query_params.get("username")
         target_user = user
 
-        if username:
+        if username and username != user.username:
             # Only allow access to other user data if the requester is an mreg superuser
             if not req_is_mreg_superuser or req_is_mreg_admin or req_is_mreg_group_admin or req_is_mreg_network_admin:
                 raise PermissionDenied("You do not have permission to view other users' details.")


### PR DESCRIPTION
BREAKING CHANGE:

`api/meta/versions` is now gone! (But this was never taken into use)

This has been replaced with `api/meta/version` (server version, open to authenticated users) and `api/meta/libraries` (core libraries, available to superusers and administrators).


