### PR TITLE
Add `meta/health/ldap` endpoint

### DIFF
--- a/mreg/api/urls.py
+++ b/mreg/api/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path('meta/user', views.UserInfo.as_view()),
     path('meta/version', views.MregVersion.as_view()),
     path('meta/libraries', views.MetaVersions.as_view()),
-    path('meta/heartbeat', views.MetaHeartbeat.as_view()),
+    path('meta/health/heartbeat', views.HealthHeartbeat.as_view()),
+    path('meta/health/ldap', views.HealthLDAP.as_view()),
 ]

--- a/mreg/api/v1/tests/tests.py
+++ b/mreg/api/v1/tests/tests.py
@@ -3,12 +3,14 @@ from operator import itemgetter
 from unittest import skip
 
 import unittest.mock as mock
+import ldap
 from unittest_parametrize import ParametrizedTestCase, param, parametrize
 
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
+from django_auth_ldap.backend import LDAPBackend
 
 from rest_framework.test import APIClient, APITestCase
 
@@ -357,12 +359,80 @@ class APIMetaTestCase(MregAPITestCase):
     def test_meta_user_info_user_not_found_404_not_found(self):
         self.assert_get_and_404("/api/meta/user?username=nonexistent")
 
-    def test_meta_heartbeat_user_200_ok(self):
+
+class APIHealthHeartbeatTestCase(MregAPITestCase):
+    """Test the heartbeat API endpoint"""
+
+    def test_meta_heartbeat_user_200_ok(self) -> None:
         self.client = self.get_token_client(superuser=False)
         response = self.assert_get("/api/meta/health/heartbeat")
-        for key in ('uptime', 'start_time'):
+        for key in ("uptime", "start_time"):
             with self.subTest(key=key):
                 self.assertTrue(key in response.data)
+
+
+class APIHealthLDAPTestCase(MregAPITestCase):
+    """Test the health API endpoint with mocked LDAP backend."""
+
+    def setUp(self):
+        super().setUp()
+
+        # Create the mock connection that will be returned by initialize
+        self.mock_connection = mock.MagicMock()
+
+        # Create a mock LDAP backend instance
+        self.mock_ldap_backend = mock.MagicMock(spec=LDAPBackend)
+        # Configure the ldap attribute and its initialize method
+        self.mock_ldap_backend.ldap.initialize.return_value = self.mock_connection
+
+        # Patch LDAPBackend in the views module
+        self.backend_patcher = mock.patch("mreg.api.views.LDAPBackend", return_value=self.mock_ldap_backend)
+        self.mock_backend_class = self.backend_patcher.start()
+        self.addCleanup(self.backend_patcher.stop)
+
+    def test_health_ldap_ok(self) -> None:
+        """Test successful LDAP health check."""
+        self.client = self.get_token_client(superuser=False)
+        
+        self.assert_get("/api/meta/health/ldap")
+
+        # Verify the connection was properly initialized and cleaned up
+        self.mock_ldap_backend.ldap.initialize.assert_called_once_with(settings.AUTH_LDAP_SERVER_URI)
+        self.mock_connection.simple_bind_s.assert_called_once_with(
+            settings.AUTH_LDAP_BIND_DN, settings.AUTH_LDAP_BIND_PASSWORD
+        )
+        self.mock_connection.unbind_s.assert_called_once()
+
+    def test_health_ldap_503_unavailable_ldap_error(self) -> None:
+        """Test LDAP health check when connection fails with LDAPError."""
+        self.client = self.get_token_client(superuser=False)
+        self.mock_connection.simple_bind_s.side_effect = ldap.LDAPError("LDAP connection error")
+
+        self._assert_get_and_status("/api/meta/health/ldap", 503)
+
+        # Verify cleanup was attempted even after error
+        self.mock_connection.unbind_s.assert_called_once()
+
+    def test_health_ldap_503_unavailable_unknown_error(self) -> None:
+        """Test LDAP health check when connection fails with unexpected error."""
+        self.client = self.get_token_client(superuser=False)
+        self.mock_connection.simple_bind_s.side_effect = Exception("LDAP is down")
+
+        self._assert_get_and_status("/api/meta/health/ldap", 503)
+
+        # Verify cleanup was attempted even after error
+        self.mock_connection.unbind_s.assert_called_once()
+
+    def test_health_ldap_cleanup_handles_unbind_error(self) -> None:
+        """Test LDAP health check properly handles errors during unbind."""
+        self.client = self.get_token_client(superuser=False)
+        self.mock_connection.unbind_s.side_effect = ldap.LDAPError("Unbind failed")
+
+        self.assert_get("/api/meta/health/ldap")
+
+        # Verify both bind and unbind were attempted
+        self.mock_connection.simple_bind_s.assert_called_once()
+        self.mock_connection.unbind_s.assert_called_once()
 
 
 class APIAutoupdateZonesTestCase(MregAPITestCase):

--- a/mreg/api/v1/tests/tests.py
+++ b/mreg/api/v1/tests/tests.py
@@ -359,7 +359,7 @@ class APIMetaTestCase(MregAPITestCase):
 
     def test_meta_heartbeat_user_200_ok(self):
         self.client = self.get_token_client(superuser=False)
-        response = self.assert_get("/api/meta/heartbeat")
+        response = self.assert_get("/api/meta/health/heartbeat")
         for key in ('uptime', 'start_time'):
             with self.subTest(key=key):
                 self.assertTrue(key in response.data)

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -192,8 +192,6 @@ class MetaVersions(APIView):
 
 class HealthHeartbeat(APIView):
 
-    permission_classes = (IsAuthenticated,)
-
     def get(self, request: Request):
         uptime = int(time.time() - start_time)
         data = {
@@ -222,7 +220,6 @@ class LDAPDetails:
 
 
 class HealthLDAP(APIView):
-    permission_classes = (IsAuthenticated,)
 
     def get(self, request: Request):
         details = self._check_ldap_connection()

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -261,8 +261,7 @@ class HealthLDAP(APIView):
 
                 results = connection.search_s(
                     test_dn,
-                    ldap.SCOPE_BASE,
-                    "(objectClass=*)",
+                    ldap.SCOPE_SUBTREE,
                     attrlist=[], # No attributes needed
                     sizelimit=1
                 )

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -206,13 +206,13 @@ class HealthHeartbeat(APIView):
 @dataclass
 class LDAPDetails:
     """Details about the LDAP connection and search test."""
-    connection_successful: bool = False
-    search_successful: bool = False
+    connect: bool = False
+    search: bool = False
     error: Optional[str] = None
 
     @property
     def healthy(self) -> bool:
-        return not self.error and all([self.connection_successful, self.search_successful])
+        return not self.error and all([self.connect, self.search])
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
@@ -264,7 +264,7 @@ class HealthLDAP(APIView):
                 settings.AUTH_LDAP_BIND_PASSWORD
             )
 
-            details.connection_successful = True
+            details.connect = True
 
             search_config = self._get_search_config()
             if search_config:
@@ -277,11 +277,11 @@ class HealthLDAP(APIView):
                     attrlist=['dn'],
                     sizelimit=1
                 )
-                details.search_successful = True
+                details.search = True
             else:
                 # If no search is configured, we'll just mark it as successful
                 # since it's not required for basic LDAP functionality
-                details.search_successful = True
+                details.search = True
                 logger.debug("No LDAP search configuration found, skipping search test")
 
             return details

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -201,7 +201,7 @@ class HealthHeartbeat(APIView):
 
 class HealthLDAP(APIView):
     def get(self, request: Request) -> Response:
-        ok = self._check_ldap_connection()
+        ok = self.check_ldap_connection()
         st = status.HTTP_200_OK if ok else status.HTTP_503_SERVICE_UNAVAILABLE
         return Response(status=st)
 
@@ -213,12 +213,11 @@ class HealthLDAP(APIView):
         """
         try:
             self._check_ldap_connection()
+            return True
         except ldap.LDAPError as e:
             logger.exception("LDAP connection error", error=str(e))
         except Exception as e:
-            logger.exception("Error during LDAP connection check", error=str(e))
-        else:
-            return True
+            logger.exception("Error during LDAP check", error=str(e))
         return False
     
     def _check_ldap_connection(self) -> None:

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -229,16 +229,16 @@ class HealthLDAP(APIView):
         return Response(status=st, data=details.to_dict())
 
     def _check_ldap_connection(self) -> LDAPDetails:
-        """Perform LDAP connection test.
+        """Perform LDAP connection and search test.
 
         Attempts to establish an LDAP connection using configured settings
-        and verify the DN template by attempting a bind.
+        and perform a basic search operation.
 
         :return: Details about the LDAP connection health status
         :rtype: LDAPDetails
         """
         details = LDAPDetails()
-        connection = None # may be bound in the try block
+        connection = None # may be set in the try block
 
         try:
             ldap_backend = LDAPBackend()
@@ -268,7 +268,7 @@ class HealthLDAP(APIView):
                 )
                 
                 details.search = bool(results)
-                if details.search:
+                if not details.search:
                     logger.warning("No users found in LDAP search. Is the LDAP server empty?", base=test_dn)
 
                     

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -82,6 +82,8 @@ AUTH_LDAP_SERVER_URI = "ldap://ldap.example.com"
 AUTH_LDAP_USER_DN_TEMPLATE = "uid=%(user)s,ou=users,dc=example,dc=com"
 AUTH_LDAP_START_TLS = True
 AUTH_LDAP_CACHE_TIMEOUT = 3600
+AUTH_LDAP_BIND_DN = ""
+AUTH_LDAP_BIND_PASSWORD = ""
 
 # Used by signals.py populate_user_from_ldap to match attributes
 # via a regexp to groups, which are added to the logged in user.


### PR DESCRIPTION
This PR adds an endpoint for checking the status of the application's LDAP connection. It performs the following actions:

1. Tries to connect to LDAP server and bind using credentials defined in settings.
2. Responds with either 200 or 503 based on success of bind operation.

The response contains no data, just a status code. LDAP internals are not exposed.

## Tasks

- [x] Add `/meta/health/ldap` endpoint
- [x] Move heartbeat endpoint to `/meta/health/heartbeat`
- [x] Add tests