### PR TITLE
Fix setuptools-scm version in container image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ wheels/
 *.egg
 MANIFEST
 mreg/_version.py
+requirements.txt
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # build stage
 FROM python:3.11-alpine AS builder
 WORKDIR /usr/src/mreg
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV UV_FROZEN=1
 
 RUN apk update
 RUN apk add --virtual build-deps gcc python3-dev openldap-dev musl-dev git

--- a/uv.lock
+++ b/uv.lock
@@ -385,7 +385,7 @@ wheels = [
 
 [[package]]
 name = "mreg"
-version = "1.1.1.dev7+gedcf871.d20241120"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -409,7 +409,7 @@ dependencies = [
 
 [package.dev-dependencies]
 ci = [
-    { name = "coverage" },
+    { name = "coverage", extra = ["toml"] },
     { name = "coveralls" },
     { name = "pytest" },
     { name = "pytest-django" },
@@ -417,7 +417,7 @@ ci = [
     { name = "tox-uv" },
 ]
 dev = [
-    { name = "coverage" },
+    { name = "coverage", extra = ["toml"] },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "tox-uv" },
@@ -446,7 +446,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 ci = [
-    { name = "coverage" },
+    { name = "coverage", extras = ["toml"] },
     { name = "coveralls" },
     { name = "pytest" },
     { name = "pytest-django" },
@@ -454,7 +454,7 @@ ci = [
     { name = "tox-uv" },
 ]
 dev = [
-    { name = "coverage" },
+    { name = "coverage", extras = ["toml"] },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "tox-uv" },
@@ -557,6 +557,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/ac/5b1ea50fc08a9df82de7e1771537557f07c2632231bbab652c7e22597908/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909", size = 2822712 },
     { url = "https://files.pythonhosted.org/packages/c4/fc/504d4503b2abc4570fac3ca56eb8fed5e437bf9c9ef13f36b6621db8ef00/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1", size = 2920155 },
     { url = "https://files.pythonhosted.org/packages/b2/d1/323581e9273ad2c0dbd1902f3fb50c441da86e894b6e25a73c3fda32c57e/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567", size = 2959356 },
+    { url = "https://files.pythonhosted.org/packages/08/50/d13ea0a054189ae1bc21af1d85b6f8bb9bbc5572991055d70ad9006fe2d6/psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142", size = 2569224 },
 ]
 
 [[package]]


### PR DESCRIPTION
Fix container image versioning for tagged releases

**Problem:**
When building container images from tagged commits, `setuptools-scm` incorrectly appends commit hash and date to the version number. This happens because our build process creates `requirements.txt`, as well as possibly modifying `uv.lock`, causing `setuptools-scm` to detect the repository as "dirty" even though we're building from a clean tagged commit.

**Solution:**
1. Add `requirements.txt` to `.gitignore` to prevent it from being tracked
2. Set `UV_FROZEN=1` environment variable to prevent any modifications to the lock file during build
3. Update lock file to match dependencies in `pyproject.toml` (was missing `coverage[toml]` from #568).

This ensures that container images built from tags (e.g., `v1.2.3`) will have clean version numbers that match the git tag instead of versions with appended hashes (e.g., `1.2.3.dev5+g123abc`).