### PR TITLE
Provide last_login and token information in the users API.

### DIFF
--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -8,6 +8,7 @@ import ldap
 import structlog
 from django.conf import settings
 from django_auth_ldap.backend import LDAPBackend
+from django.contrib.auth.models import update_last_login
 from psycopg2 import __libpq_version__ as libpq_version
 from rest_framework import serializers, status
 from rest_framework.authtoken.views import ObtainAuthToken
@@ -75,6 +76,12 @@ class ObtainExpiringAuthToken(ObtainAuthToken):
             ExpiringToken.objects.filter(user=user).delete()
             token, _ = ExpiringToken.objects.get_or_create(user=user)
 
+        # django.contrib.auth.models.update_last_login expects to be a signal receiver.
+        # But, it does not use its first argument, so it is safe to pass it None even if
+        # the stubs complain.
+        userobject = User.objects.get(username=user)
+        update_last_login(None, userobject) # type: ignore[call-arg]
+
         return Response({"token": token.key})
 
 
@@ -125,8 +132,21 @@ class UserInfo(APIView):
             group__in=[group.name for group in target_groups]
         )
         
+        token = ExpiringToken.objects.filter(user=target_user).first()
+        token_data = None
+        if token:
+            token_data = {
+                "is_valid": not token.is_expired,
+                "created": token.created_at.astimezone(),
+                "expire": token.expire_at.astimezone(),
+                "last_used": token.last_used.astimezone() if token.last_used else None,
+                "lifespan_left": str(token.lifespan_left)
+            }
+            
         data = {
             "username": target_user.username,
+            "last_login": target_user.last_login.astimezone() if target_user.last_login else None,
+            "token": token_data if token else None,
             "django_status": {
                 "superuser": target_user.is_superuser,
                 "staff": target_user.is_staff,

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -140,7 +140,7 @@ class UserInfo(APIView):
                 "created": token.created_at.astimezone(),
                 "expire": token.expire_at.astimezone(),
                 "last_used": token.last_used.astimezone() if token.last_used else None,
-                "lifespan_left": str(token.lifespan_left)
+                "lifespan": str(token.lifespan_left)
             }
             
         data = {

--- a/mreg/models/base.py
+++ b/mreg/models/base.py
@@ -152,7 +152,25 @@ class ForwardZoneMember(BaseModel):
 class ExpiringToken(Token):
     last_used = models.DateTimeField(auto_now=True)
 
+    @classmethod
+    def expire_time_in_hours(cls) -> int:
+        """
+        Return the expiration time for the token.
+        """
+        return getattr(settings, "REST_FRAMEWORK_TOKEN_EXPIRE_HOURS", 8)
+
     @property
     def is_expired(self):
-        EXPIRE_HOURS = getattr(settings, "REST_FRAMEWORK_TOKEN_EXPIRE_HOURS", 8)
-        return self.last_used < timezone.now() - timedelta(hours=EXPIRE_HOURS)
+        return self.last_used < timezone.now() - timedelta(hours=self.expire_time_in_hours())
+
+    @property
+    def created_at(self):
+        return self.created
+
+    @property
+    def expire_at(self):
+        return self.created + timedelta(hours=self.expire_time_in_hours())
+    
+    @property
+    def lifespan_left(self):
+        return self.expire_at - timezone.now()


### PR DESCRIPTION
Show information about the last time the user logged in, and if it exists the last token the server knows about for the user:

For a user who has logged in and used a token:

```json
{
  "username": "hasloggedin",
  "last_login": "2025-05-13T10:05:17.553790+02:00",
  "token": {
    "is_valid": true,
    "created": "2025-05-13T10:05:17.526321+02:00",
    "expire": "2025-05-13T18:05:17.526321+02:00",
    "last_used": "2025-05-13T10:35:46.536021+02:00",
    "lifespan_left": "7:29:30.958632"
  },
  "django_status": {
    "superuser": false,
    "staff": false,
    "active": true
  },
  "mreg_status": {
    "superuser": true,
    "admin": false,
    "group_admin": false,
    "network_admin": false,
    "hostpolicy_admin": false,
    "dns_wildcard_admin": false,
    "underscore_admin": false
  },
  "groups": [
    "default-super-group"
  ],
  "permissions": []
}
```

For someone not so fortunate:

```json
{
  "username": "notloggedin",
  "last_login": null,
  "token": null,
  "django_status": {
    "superuser": false,
    "staff": false,
    "active": true
  },
  "mreg_status": {
    "superuser": true,
    "admin": false,
    "group_admin": false,
    "network_admin": false,
    "hostpolicy_admin": false,
    "dns_wildcard_admin": false,
    "underscore_admin": false
  },
  "groups": [
    "default-super-group"
  ],
  "permissions": []
}
```