### PR TITLE
Add basic type validation/coercion of env vars in settings.py

### DIFF
--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -28,10 +28,9 @@ def envvar(var: str, default: DefaultT) -> DefaultT:
     
     The type of the default value specifies the return type.
     """
-    val = os.environ.get(var, None)
-    v = val if val is not None else default
+    val = os.environ.get(var, default)
     try:
-        return type(default)(v)
+        return type(default)(val)
     except ValueError:
         return default
 

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -28,7 +28,7 @@ def envvar(var: str, default: DefaultT) -> DefaultT:
     
     The type of the default value specifies the return type.
     """
-    val = envvar(var, None)
+    val = os.environ.get(var, None)
     if val is None or default is None:
         return default
     

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -13,10 +13,19 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 import logging.config
 import os
 import sys
+from typing import Literal
 
 import structlog
 
 import mreg.log_processors
+
+
+def envvar_bool(var: str, default: Literal["true", "false"] = "false"):
+    """Return the value of an environment variable as a boolean."""
+    value = os.environ.get(var, default).lower()
+    if value in ["true", "1", "yes", "y"]:
+        return True
+    return False
 
 TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"
 
@@ -54,7 +63,7 @@ MREG_CREATING_COMMUNITY_REQUIRES_POLICY_WITH_ATTRIBUTES = [] # [ "isolated" ]
 
 MREG_MAX_COMMUNITES_PER_NETWORK = 20
 
-MREG_MAP_GLOBAL_COMMUNITY_NAMES = False
+MREG_MAP_GLOBAL_COMMUNITY_NAMES = envvar_bool("MREG_MAP_GLOBAL_COMMUNITY_NAMES")
 MREG_GLOBAL_COMMUNITY_PREFIX = "community"
 MREG_COMMUNITY_PREFIX_ALLOWED_REGEX = r"^[a-zA-Z0-9_]+$"
 MREG_COMMUNITY_PREFIX_MAX_LENGTH = 100

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -29,23 +29,11 @@ def envvar(var: str, default: DefaultT) -> DefaultT:
     The type of the default value specifies the return type.
     """
     val = os.environ.get(var, None)
-    if val is None:
+    v = val if val is not None else default
+    try:
+        return type(default)(v)
+    except ValueError:
         return default
-    
-    if isinstance(default, str):
-        return val
-    elif isinstance(default, bool):
-        return str(val).lower() in ["true", "1", "yes", "y"]
-    elif isinstance(default, int):
-        try:
-            return int(val)
-        except ValueError:
-            return default
-    elif isinstance(default, float): # pyright: ignore[reportUnnecessaryIsInstance] # type is always float here, but we might want to expand this in the future?
-        try:
-            return float(val)
-        except ValueError:
-            return default
 
 
 TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -13,16 +13,16 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 import logging.config
 import os
 import sys
-from typing import Literal
 
 import structlog
 
 import mreg.log_processors
 
 
-def envvar_bool(var: str, default: Literal["true", "false"] = "false"):
+def envvar_bool(var: str, default: bool) -> bool:
     """Return the value of an environment variable as a boolean."""
-    value = os.environ.get(var, default).lower()
+    d = str(default).lower()
+    value = os.environ.get(var, d).lower()
     if value in ["true", "1", "yes", "y"]:
         return True
     return False
@@ -63,7 +63,7 @@ MREG_CREATING_COMMUNITY_REQUIRES_POLICY_WITH_ATTRIBUTES = [] # [ "isolated" ]
 
 MREG_MAX_COMMUNITES_PER_NETWORK = 20
 
-MREG_MAP_GLOBAL_COMMUNITY_NAMES = envvar_bool("MREG_MAP_GLOBAL_COMMUNITY_NAMES")
+MREG_MAP_GLOBAL_COMMUNITY_NAMES = envvar_bool("MREG_MAP_GLOBAL_COMMUNITY_NAMES", False)
 MREG_GLOBAL_COMMUNITY_PREFIX = "community"
 MREG_COMMUNITY_PREFIX_ALLOWED_REGEX = r"^[a-zA-Z0-9_]+$"
 MREG_COMMUNITY_PREFIX_MAX_LENGTH = 100

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -20,7 +20,7 @@ import structlog
 import mreg.log_processors
 
 
-DefaultT = TypeVar("DefaultT", str, int, float, bool, None)
+DefaultT = TypeVar("DefaultT", str, int, float, bool)
 
 
 def envvar(var: str, default: DefaultT) -> DefaultT:
@@ -29,7 +29,7 @@ def envvar(var: str, default: DefaultT) -> DefaultT:
     The type of the default value specifies the return type.
     """
     val = os.environ.get(var, None)
-    if val is None or default is None:
+    if val is None:
         return default
     
     if isinstance(default, str):


### PR DESCRIPTION
For #572 

This PR adds rudimentary type validation and coercion of environment variable values. By specifying a default value, the value retrieved from the environment is coerced to the same type as the default value. If the value cannot be coerced to that type, the default value is returned instead.

This PR also exposes `MREG_MAP_GLOBAL_COMMUNITY_NAMES` as a boolean value (`1`, `true`, `y`, `yes`) via an environment value with the same name.