### PR TITLE
Add network admin check when creating hosts with network/broadcast addr

### DIFF
--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -364,9 +364,8 @@ class IsGrantedReservedAddressPermission(IsAuthenticated):
         try:
             ipaddr = ipaddress.ip_address(ip)
         except ValueError:
-            raise exceptions.ValidationError(
-                {"ipaddress": "Invalid IP address."},
-            )
+            # invalid IP, let serializer handle it
+            return True 
 
         try:
             network: Network = Network.objects.get(network__net_contains=ip)
@@ -388,7 +387,7 @@ class IsGrantedReservedAddressPermission(IsAuthenticated):
     def has_destroy_permission(self, request: Request, view: ListCreateAPIView, validated_serializer: BaseModel):
         # Deleting will never assign IPs. 
         # Furthermore, the permissions check in `perform_destroy` passes 
-        # in an _instance_ instead of a serializer when checking destroy 
-        # permissions, thus we cannot access any sort of validated data.
+        # in a BaseModel _instance_ instead of a serializer when checking
+        # destroy permissions, so we cannot access any sort of validated data.
         return self.has_permission(request, view)
 

--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -17,7 +17,7 @@ from mreg.models.auth import User
 # the `DEFAULT_PERMISSION_CLASSES` we defined in `settings.py`, causing
 # an import cycle if we _actually_ import the generics module on runtime.
 if TYPE_CHECKING:
-    from rest_framework.generics import ListCreateAPIView
+    from rest_framework.generics import GenericAPIView
     from rest_framework.serializers import Serializer
     from mreg.models.base import BaseModel
 
@@ -334,7 +334,7 @@ class HostGroupPermission(IsAuthenticated):
 
 
 class IsGrantedReservedAddressPermission(IsAuthenticated):
-    def has_ipaddress_permission(self, request: Request, view: ListCreateAPIView, validated_serializer: Serializer):
+    def has_ipaddress_permission(self, request: Request, view: GenericAPIView, validated_serializer: Serializer):
         import mreg.api.v1.views
 
         user = User.from_request(request)
@@ -378,13 +378,13 @@ class IsGrantedReservedAddressPermission(IsAuthenticated):
                 )
         return True
 
-    def has_create_permission(self, request: Request, view: ListCreateAPIView, validated_serializer: Serializer):
+    def has_create_permission(self, request: Request, view: GenericAPIView, validated_serializer: Serializer):
         return self.has_ipaddress_permission(request, view, validated_serializer)
 
-    def has_update_permission(self, request: Request, view: ListCreateAPIView, validated_serializer: Serializer):
+    def has_update_permission(self, request: Request, view: GenericAPIView, validated_serializer: Serializer):
         return self.has_ipaddress_permission(request, view, validated_serializer)
 
-    def has_destroy_permission(self, request: Request, view: ListCreateAPIView, validated_serializer: BaseModel):
+    def has_destroy_permission(self, request: Request, view: GenericAPIView, validated_serializer: BaseModel):
         # Deleting will never assign IPs. 
         # Furthermore, the permissions check in `perform_destroy` passes 
         # in a BaseModel _instance_ instead of a serializer when checking

--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -335,23 +335,8 @@ class HostGroupPermission(IsAuthenticated):
 
 class IsGrantedReservedAddressPermission(IsAuthenticated):
     def has_ipaddress_permission(self, request: Request, view: GenericAPIView, validated_serializer: Serializer):
-        import mreg.api.v1.views
-
         user = User.from_request(request)
         if (user.is_mreg_superuser_or_admin or user.is_mreg_network_admin):
-            return True
-
-        if not isinstance(
-            view, 
-            (
-                mreg.api.v1.views.HostList,
-                mreg.api.v1.views.HostDetail,
-                mreg.api.v1.views.IpaddressDetail,
-                mreg.api.v1.views.IpaddressList,
-                mreg.api.v1.views.PtrOverrideDetail,
-                mreg.api.v1.views.PtrOverrideList
-            )
-        ):
             return True
         
         if not hasattr(validated_serializer, "validated_data"):

--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -341,11 +341,17 @@ class IsGrantedReservedAddressPermission(IsAuthenticated):
         if (user.is_mreg_superuser_or_admin or user.is_mreg_network_admin):
             return True
 
-        if isinstance(view, (
-                        mreg.api.v1.views.HostList,
-                        mreg.api.v1.views.HostDetail,
-                        mreg.api.v1.views.IpaddressList,
-                        mreg.api.v1.views.PtrOverrideList)):
+        if not isinstance(
+            view, 
+            (
+                mreg.api.v1.views.HostList,
+                mreg.api.v1.views.HostDetail,
+                mreg.api.v1.views.IpaddressDetail,
+                mreg.api.v1.views.IpaddressList,
+                mreg.api.v1.views.PtrOverrideDetail,
+                mreg.api.v1.views.PtrOverrideList
+            )
+        ):
             return True
         
         if not hasattr(validated_serializer, "validated_data"):

--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -13,7 +13,7 @@ from mreg.models.network import NetGroupRegexPermission, Network
 from mreg.models.auth import User
 
 # NOTE: We _must_ import `rest_framework.generics` in an `if TYPE_CHECKING:`
-# block because DRF does some dyanmic import shenanigans on runtime using
+# block because DRF does some dynamic import shenanigans on runtime using
 # the `DEFAULT_PERMISSION_CLASSES` we defined in `settings.py`, causing
 # an import cycle if we _actually_ import the generics module on runtime.
 if TYPE_CHECKING:
@@ -372,7 +372,7 @@ class IsGrantedReservedAddressPermission(IsAuthenticated):
     def has_destroy_permission(self, request: Request, view: GenericAPIView, validated_serializer: BaseModel):
         # Deleting will never assign IPs. 
         # Furthermore, the permissions check in `perform_destroy` passes 
-        # in a BaseModel _instance_ instead of a serializer when checking
+        # in a `BaseModel` instance instead of a serializer when checking
         # destroy permissions, so we cannot access any sort of validated data.
         return self.has_permission(request, view)
 

--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -365,9 +365,6 @@ class IsGrantedReservedAddressPermission(IsAuthenticated):
         user = User.from_request(request)
         if (user.is_mreg_superuser_or_admin or user.is_mreg_network_admin):
             return True
-        
-        if not hasattr(validated_serializer, "validated_data"):
-            return True
 
         data = validated_serializer.validated_data   
         if not data or not (ip := data.get("ipaddress")):

--- a/mreg/api/v1/tests/test_permissions.py
+++ b/mreg/api/v1/tests/test_permissions.py
@@ -1,11 +1,13 @@
-
 from unittest import mock
 
+from django.conf import settings
+from django.contrib.auth.models import Group
 from django.test import RequestFactory
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.test import APIClient, force_authenticate
-
 from mreg.api.permissions import IsGrantedNetGroupRegexPermission
+from mreg.models.host import Host, Ipaddress
+from mreg.models.network import Network, NetGroupRegexPermission
 
 from .tests import MregAPITestCase
 
@@ -130,3 +132,226 @@ class NetGroupRegexPermissionTestCaseAsAdmin(NetGroupRegexPermissionTestCase):
 
     def setUp(self):
         self.client = self.get_token_client(superuser=False, adminuser=True)
+
+
+class ReservedAddressPermissionsTestCase(MregAPITestCase):
+    """Test IsGrantedReservedAddressPermission for network and broadcast addresses."""
+
+    def setUp(self):
+        super().setUp()
+        # Create test networks
+        self.network_ipv4 = Network.objects.create(
+            network='10.0.0.0/24', 
+            description='Test IPv4 network'
+        )
+        self.network_ipv6 = Network.objects.create(
+            network='2001:db8::/64', 
+            description='Test IPv6 network'
+        )
+        
+        # Network addresses
+        self.ipv4_network_addr = '10.0.0.0'      # network address
+        self.ipv4_broadcast_addr = '10.0.0.255'  # broadcast address
+        self.ipv4_regular_addr = '10.0.0.10'     # regular address
+        
+        # IPv6 only has network address (no broadcast)
+        self.ipv6_network_addr = '2001:db8::'    # network address
+        self.ipv6_regular_addr = '2001:db8::10'  # regular address
+
+    def test_superuser_can_use_reserved_addresses(self):
+        """Superusers should be able to use network and broadcast addresses."""
+        # Test with IPv4 network address
+        data = {'name': 'test-network.example.org', 'ipaddress': self.ipv4_network_addr}
+        self.assert_post_and_201('/hosts/', data)
+        
+        # Test with IPv4 broadcast address
+        data = {'name': 'test-broadcast.example.org', 'ipaddress': self.ipv4_broadcast_addr}
+        self.assert_post_and_201('/hosts/', data)
+        
+        # Test with IPv6 network address
+        data = {'name': 'test-ipv6-network.example.org', 'ipaddress': self.ipv6_network_addr}
+        self.assert_post_and_201('/hosts/', data)
+
+    def test_network_admin_can_use_reserved_addresses(self):
+        """Network admins should be able to use reserved addresses."""
+        with self.temporary_client_as_network_admin():
+            self.add_user_to_groups("NETWORK_ADMIN_GROUP")
+            NetGroupRegexPermission.objects.create(
+                group=settings.NETWORK_ADMIN_GROUP,
+                range=self.network_ipv4.network,
+                regex=r'.*\.example\.org$'
+            )
+            # Test with IPv4 network address
+            data = {'name': 'test-network.example.org', 'ipaddress': self.ipv4_network_addr}
+            self.assert_post_and_201('/hosts/', data)
+            
+            # Test with IPv4 broadcast address
+            data = {'name': 'test-broadcast.example.org', 'ipaddress': self.ipv4_broadcast_addr}
+            self.assert_post_and_201('/hosts/', data)
+
+    def test_regular_user_cannot_use_reserved_addresses(self):
+        """Regular users should not be able to use network and broadcast addresses."""
+        with self.temporary_client_as_normal_user():       
+            # Test with IPv4 network address - should fail
+            data = {'name': 'test-network.example.org', 'ipaddress': self.ipv4_network_addr}
+            self.assert_post_and_403('/hosts/', data)
+            
+            # Test with IPv4 broadcast address - should fail
+            data = {'name': 'test-broadcast.example.org', 'ipaddress': self.ipv4_broadcast_addr}
+            self.assert_post_and_403('/hosts/', data)
+            
+            # Test with IPv6 network address - should fail
+            data = {'name': 'test-ipv6-network.example.org', 'ipaddress': self.ipv6_network_addr}
+            self.assert_post_and_403('/hosts/', data)
+
+    def test_regular_user_can_use_normal_addresses(self):
+        """Regular users should be able to use normal addresses."""
+        with self.temporary_client_as_normal_user():
+            # Grant network permissions for regular testing
+            group = Group.objects.create(name='testgroup')
+            group.user_set.add(self.user)
+            NetGroupRegexPermission.objects.create(
+                group='testgroup',
+                range='10.0.0.0/24',
+                regex=r'.*\.example\.org$'
+            )
+            NetGroupRegexPermission.objects.create(
+                group='testgroup',
+                range='2001:db8::/64',
+                regex=r'.*\.example\.org$'
+            )
+            
+            # Test with regular IPv4 address - should work
+            data = {'name': 'test-regular.example.org', 'ipaddress': self.ipv4_regular_addr}
+            self.assert_post_and_201('/hosts/', data)
+            
+            # Test with regular IPv6 address - should work
+            data = {'name': 'test-regular-ipv6.example.org', 'ipaddress': self.ipv6_regular_addr}
+            self.assert_post_and_201('/hosts/', data)
+
+    def test_ipaddress_endpoint_reserved_addresses(self):
+        """Test reserved address restrictions on /ipaddresses/ endpoint."""
+        # Create a host first
+        host = Host.objects.create(name='test.example.org')
+        
+        # Superuser can create reserved IP addresses
+        data = {'host': host.id, 'ipaddress': self.ipv4_network_addr}
+        self.assert_post_and_201('/ipaddresses/', data)
+        
+        # Regular user cannot
+        with self.temporary_client_as_normal_user():
+            data = {'host': host.id, 'ipaddress': self.ipv4_broadcast_addr}
+            self.assert_post_and_403('/ipaddresses/', data)
+
+    def test_ptroverride_endpoint_reserved_addresses(self):
+        """Test reserved address restrictions on /ptroverrides/ endpoint."""
+        # Create a host first
+        host = Host.objects.create(name='test.example.org')
+        
+        # Superuser can create reserved IP addresses
+        data = {'host': host.id, 'ipaddress': self.ipv4_network_addr}
+        self.assert_post_and_201('/ptroverrides/', data)
+        
+        # Regular user cannot
+        with self.temporary_client_as_normal_user():
+            data = {'host': host.id, 'ipaddress': self.ipv4_broadcast_addr}
+            self.assert_post_and_403('/ptroverrides/', data)
+
+    def test_update_to_reserved_address_restricted(self):
+        """Test that updating an IP to a reserved address is restricted."""
+        # Create host and IP as superuser
+        host = Host.objects.create(name='test.example.org')
+        ip = Ipaddress.objects.create(host=host, ipaddress=self.ipv4_regular_addr)
+
+        data = {'ipaddresses': self.ipv4_network_addr}
+
+        # Regular user cannot update to reserved address
+        with self.temporary_client_as_normal_user():
+            self.assert_patch_and_403(f'/hosts/{host.name}', data)
+            
+        # But superuser can
+        self.assert_patch_and_204(f"/hosts/{host.name}", data)
+
+    def test_network_outside_mreg_not_restricted(self):
+        """Test that IPs in networks not managed by mreg are not restricted."""
+        # Create a host in a network outside MREG
+        host = Host.objects.create(name="test-external.example.org")
+        Ipaddress.objects.create(host=host, ipaddress="192.168.1.123")
+
+        with self.temporary_client_as_normal_user():
+            group = Group.objects.create(name='testgroup')
+            group.user_set.add(self.user)
+            NetGroupRegexPermission.objects.create(
+                group='testgroup',
+                range='192.168.1.0/24',
+                regex=r'.*\.example\.org$'
+            )
+            
+            # Assign what would be a network address in the context of
+            # the given network
+            data = {'host': host.id, 'ipaddress': '192.168.1.0'}
+            self.assert_post_and_201("/ipaddresses/", data)
+
+    def test_delete_operations_not_restricted(self):
+        """Test that delete operations are not restricted by this permission."""
+        # Create host with reserved address as superuser
+        host = Host.objects.create(name='test.example.org')
+        ip = Ipaddress.objects.create(host=host, ipaddress=self.ipv4_network_addr)
+        
+        # Regular user should be able to delete (if they have other necessary permissions)
+        # Note: This test might fail due to other permission restrictions, but should not
+        # fail specifically due to the reserved address permission
+        with self.temporary_client_as_normal_user():
+            # Grant the user permission to the host to test deletion specifically
+            group = Group.objects.create(name='testgroup')
+            group.user_set.add(self.user)
+            NetGroupRegexPermission.objects.create(
+                group='testgroup',
+                range='10.0.0.0/24',
+                regex=r'.*\.example\.org$'
+            )
+            
+            # The delete should work (reserved address permission doesn't apply to deletes)
+            self.assert_delete_and_204(f'/ipaddresses/{ip.id}')
+
+
+class ReservedAddressPermissionsEdgeCasesTestCase(MregAPITestCase):
+    """Test edge cases for reserved address permissions."""
+    
+    def setUp(self):
+        super().setUp()
+        # Create a /30 network (very small network for edge case testing)
+        self.small_network = Network.objects.create(
+            network='192.168.1.0/30',
+            description='Small test network'
+        )
+        # In a /30: .0 = network, .1 = first host, .2 = second host, .3 = broadcast
+        
+    def test_small_network_reserved_addresses(self):
+        """Test reserved addresses in very small networks."""
+        self.client = self.get_token_client(superuser=False)
+        
+        # Network address should be restricted
+        data = {'name': 'test1.example.org', 'ipaddress': '192.168.1.0'}
+        self.assert_post_and_403('/hosts/', data)
+        
+        # Broadcast address should be restricted  
+        data = {'name': 'test2.example.org', 'ipaddress': '192.168.1.3'}
+        self.assert_post_and_403('/hosts/', data)
+
+    def test_single_host_network(self):
+        """Test /32 networks (single host)."""
+        Network.objects.create(
+            network='192.168.2.1/32',
+            description='Single host network'
+        )
+        
+        
+        # In a /32, the network address and the host address are the same
+        # This should be restricted for regular users
+        with self.temporary_client_as_normal_user():
+            data = {'name': 'test.example.org', 'ipaddress': '192.168.2.1'}
+            self.assert_post_and_403('/hosts/', data)
+        
+        # But should work for superusers
+        self.assert_post_and_201('/hosts/', data)

--- a/mreg/api/v1/tests/test_permissions.py
+++ b/mreg/api/v1/tests/test_permissions.py
@@ -177,8 +177,6 @@ class NetGroupRegexPermissionTestCaseAsAdmin(NetGroupRegexPermissionTestCase):
         self.client = self.get_token_client(superuser=False, adminuser=True)
 
 
-
-
 class ReservedAddressPermissionsTestCase(MregAPITestCase):
     """Test IsGrantedReservedAddressPermission for network and broadcast addresses."""
 
@@ -256,6 +254,8 @@ class ReservedAddressPermissionsTestCase(MregAPITestCase):
 
         permission = IsGrantedReservedAddressPermission()
 
+        # We are passing in a reserved IP address, so the permission class should
+        # deny the request for a normal user
         with self.assertRaises(PermissionDenied):
             permission.has_create_permission(request, view, serializer)
 

--- a/mreg/api/v1/tests/test_permissions.py
+++ b/mreg/api/v1/tests/test_permissions.py
@@ -390,24 +390,24 @@ class ReservedAddressPermissionsTestCase(MregAPITestCase):
             network='192.168.1.0/30',
             description='Small test network'
         )
-        group = Group.objects.create(name='small_network_group')
-        NetGroupRegexPermission.objects.create(
-                group='small_network_group',
-                range="192.168.1.0/30",
-                regex=r'.*\.example\.org$'
-        )
-        # Data for testing reserved addresses
+
+        # Create permissions for the small network
+        for group in [settings.NETWORK_ADMIN_GROUP, self.regular_user_group.name]:
+            NetGroupRegexPermission.objects.create(
+                    group=group,
+                    range="192.168.1.0/30",
+                    regex=r'.*\.example\.org$'
+            )
+
         host_nwaddr = {'name': 'nwaddr.example.org', 'ipaddress': "192.168.1.0"}
         host_bcaddr = {'name': 'bcaddr.example.org', 'ipaddress': "192.168.1.3"}
-
+        
         # Regular user denied
         with self.temporary_client_as_normal_user():
-            group.user_set.add(self.user)
             self.assert_post_and_403('/hosts/', host_nwaddr)
             self.assert_post_and_403('/hosts/', host_bcaddr)
 
         # Network admin permitted
         with self.temporary_client_as_network_admin():
-            group.user_set.add(self.user)
             self.assert_post_and_201('/hosts/', host_nwaddr)
             self.assert_post_and_201('/hosts/', host_bcaddr)

--- a/mreg/api/v1/tests/test_permissions.py
+++ b/mreg/api/v1/tests/test_permissions.py
@@ -1,4 +1,4 @@
-from enum import StrEnum
+from enum import Enum
 from unittest import mock
 
 from django.conf import settings
@@ -203,7 +203,7 @@ class ReservedAddressPermissionsTestCase(MregAPITestCase):
         self.ipv6_network_addr = '2001:db8::'    # network address
         self.ipv6_regular_addr = '2001:db8::10'  # regular address
 
-        class ReservedAddress(StrEnum):
+        class ReservedAddress(str, Enum):
             IPV4_NETWORK = self.ipv4_network_addr
             IPV4_BROADCAST = self.ipv4_broadcast_addr
             IPV6_NETWORK = self.ipv6_network_addr

--- a/mreg/api/v1/tests/tests.py
+++ b/mreg/api/v1/tests/tests.py
@@ -151,6 +151,8 @@ class MregAPITestCase(APITestCase):
             else:
                 username = 'nobody'
         usermodel = get_user_model()
+        # NOTE: We manually check and create a user, since `get_or_create` would not
+        # call `create_user` like one might expect it to (don't ask why).
         if not (user := usermodel.objects.filter(username=username).first()):
             user = usermodel.objects.create_user(username=username, password="test")
         self.user = cast(User, user)

--- a/mreg/api/v1/tests/tests.py
+++ b/mreg/api/v1/tests/tests.py
@@ -150,8 +150,10 @@ class MregAPITestCase(APITestCase):
                 username = 'networkadmin'
             else:
                 username = 'nobody'
-        self.user = cast(User, get_user_model().objects.create_user(username=username,
-                                                         password="test"))
+        usermodel = get_user_model()
+        if not (user := usermodel.objects.filter(username=username).first()):
+            user = usermodel.objects.create_user(username=username, password="test")
+        self.user = cast(User, user)
         self.user.groups.clear()
         token, _ = ExpiringToken.objects.get_or_create(user=self.user)
         if superuser:

--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -10,10 +10,12 @@ from django_filters import rest_framework as rest_filters
 
 from rest_framework import filters, generics, status
 from rest_framework.decorators import api_view
-from rest_framework.exceptions import MethodNotAllowed, ParseError, UnsupportedMediaType
+from rest_framework.exceptions import MethodNotAllowed, ParseError, PermissionDenied, UnsupportedMediaType, ValidationError
 from rest_framework.renderers import JSONRenderer
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from mreg.models.auth import User
 from mreg.models.base import NameServer, History
 from mreg.models.host import Host, Ipaddress, PtrOverride
 from mreg.models.network import Network, NetGroupRegexPermission
@@ -353,6 +355,36 @@ class HostList(HostPermissionsListCreateAPIView):
         qs = _host_prefetcher(super().get_queryset())
         return HostFilterSet(data=self.request.GET, queryset=qs).qs
 
+
+    def _create_ip(self, request: Request, host: Host, ip: str) -> None:
+        # We need an IP Address object to compare against the
+        # network and broadcast addresses of its network. 
+        try:
+            ipaddr = ipaddress.ip_address(ip)
+        except ValueError:
+            raise ValidationError(
+                {"ipaddress": "Invalid IP address."},
+            )
+
+        
+        try:
+            network: Network = Network.objects.get(network__net_contains=ip)
+        except Network.DoesNotExist:
+            raise ValidationError(
+                {"ipaddress": "No network found for the IP address."}
+            )
+        
+        if ipaddr in (network.network.broadcast_address, network.network.network_address):
+            user = User.from_request(request)
+            if not (user.is_mreg_superuser_or_admin or user.is_mreg_network_admin):
+                raise PermissionDenied(
+                    {"ERROR": "Setting a network or broadcast address on a host requires network admin privileges."}
+                )
+        
+        ipserializer = IpaddressSerializer(Ipaddress(), data={"host": host.pk, "ipaddress": ip})
+        ipserializer.is_valid(raise_exception=True)
+        self.perform_create(ipserializer)
+
     def post(self, request, *args, **kwargs):
         community = None
         if "network_community" in request.data:
@@ -434,11 +466,7 @@ class HostList(HostPermissionsListCreateAPIView):
                     # self.perform_create(hostserializer)
                     hostserializer.save()
                     self.save_log_create(hostserializer)
-                    ipdata = {"host": host.pk, "ipaddress": ipkey}
-                    ip = Ipaddress()
-                    ipserializer = IpaddressSerializer(ip, data=ipdata)
-                    ipserializer.is_valid(raise_exception=True)
-                    self.perform_create(ipserializer)
+                    self._create_ip(request, host, ipkey)
 
                     if community:
                         host.add_to_community(community)

--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -366,20 +366,17 @@ class HostList(HostPermissionsListCreateAPIView):
                 {"ipaddress": "Invalid IP address."},
             )
 
-        
         try:
             network: Network = Network.objects.get(network__net_contains=ip)
         except Network.DoesNotExist:
-            raise ValidationError(
-                {"ipaddress": "No network found for the IP address."}
-            )
-        
-        if ipaddr in (network.network.broadcast_address, network.network.network_address):
-            user = User.from_request(request)
-            if not (user.is_mreg_superuser_or_admin or user.is_mreg_network_admin):
-                raise PermissionDenied(
-                    {"ERROR": "Setting a network or broadcast address on a host requires network admin privileges."}
-                )
+            pass # network not in mreg
+        else:
+            if ipaddr in (network.network.broadcast_address, network.network.network_address):
+                user = User.from_request(request)
+                if not (user.is_mreg_superuser_or_admin or user.is_mreg_network_admin):
+                    raise PermissionDenied(
+                        {"ERROR": "Setting a network or broadcast address on a host requires network admin privileges."}
+                    )
         
         ipserializer = IpaddressSerializer(Ipaddress(), data={"host": host.pk, "ipaddress": ip})
         ipserializer.is_valid(raise_exception=True)

--- a/mreg/models/network.py
+++ b/mreg/models/network.py
@@ -275,6 +275,7 @@ class NetGroupRegexPermission(BaseModel):
         )
         if require_ip:
             qs = qs.filter(
-                reduce(lambda x, y: x | y, [Q(range__net_contains=ip) for ip in ips])
+                # NOTE: using `contains_or_equals` to match /32 (v4) and /128 (v6) CIDR ranges
+                reduce(lambda x, y: x | y, [Q(range__net_contains_or_equals=ip) for ip in ips])
             )
         return qs

--- a/mreg/models/network.py
+++ b/mreg/models/network.py
@@ -276,6 +276,6 @@ class NetGroupRegexPermission(BaseModel):
         if require_ip:
             qs = qs.filter(
                 # NOTE: using `contains_or_equals` to match /32 (v4) and /128 (v6) CIDR ranges
-                reduce(lambda x, y: x | y, [Q(range__net_contains_or_equals=ip) for ip in ips])
+                reduce(lambda x, y: x | y, [Q(range__net_contains=ip) for ip in ips])
             )
         return qs

--- a/mreg/models/network.py
+++ b/mreg/models/network.py
@@ -275,7 +275,6 @@ class NetGroupRegexPermission(BaseModel):
         )
         if require_ip:
             qs = qs.filter(
-                # NOTE: using `contains_or_equals` to match /32 (v4) and /128 (v6) CIDR ranges
                 reduce(lambda x, y: x | y, [Q(range__net_contains=ip) for ip in ips])
             )
         return qs


### PR DESCRIPTION
## Issue

Network administrators want to be able to create hosts with ip addresses that overlap with network or broadcast addresses. It has technically always been possible through the API, but we prevented users from doing so in the CLI. We want to allow network admins to do so through the CLI, and thus we need to implement this check server-side.

## Solution

Adds a permissions check when creating hosts with an ip address that is identical to the network's network or broadcast address. The user _must_ be an admin or a network admin in order to use such IP addresses when creating hosts.