### PR TITLE
Remove limited PATCH permissions for network admins on `/networks/<network>` endpoint

### DIFF
--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -87,7 +87,6 @@ class IsSuperOrNetworkAdminMember(IsAuthenticated):
     """
 
     def has_permission(self, request, view):
-        import mreg.api.v1.views
         if not super().has_permission(request, view):
             return False
 
@@ -95,16 +94,7 @@ class IsSuperOrNetworkAdminMember(IsAuthenticated):
         if user.is_mreg_superuser:
             return True
         if user.is_mreg_network_admin:
-            if isinstance(view, mreg.api.v1.views.NetworkDetail):
-                if request.method == 'PATCH':
-                    # Only allow update of the reserved/frozen fields
-                    allowed_fields = {'frozen', 'reserved'}
-                    if allowed_fields.issuperset(request.data):
-                        return True
-                return False
-
             return True
-
         return False
 
 

--- a/mreg/api/v1/tests/test_networks.py
+++ b/mreg/api/v1/tests/test_networks.py
@@ -615,18 +615,3 @@ class NetworkAdminPermissions(NetworkExcludedRanges):
         self.client = self.get_token_client(username='networkadmin',
                                             superuser=False, adminuser=True)
         self.add_user_to_groups('NETWORK_ADMIN_GROUP')
-
-    def test_can_only_patch_reserved(self):
-        """
-        Test that members of NETWORK_ADMIN_GROUP can patch the reserved field, and
-        the frozen field, but nothing else.
-        """
-        path = '/api/v1/networks/10.0.0.0/24'
-        self.assert_patch(path, {'reserved': 5})
-        self.assert_patch_and_403(path, {'description': 'test2'})
-        self.assert_patch(path, {'frozen': True})
-        self.assert_patch(path, {'frozen': False, 'reserved': 7})
-        # Only allowed to do a patch with reserved and/or frozen. Not other fields at the same time.
-        self.assert_patch_and_403(path, {'reserved': 2, 'description': 'test2'})
-        self.assert_patch_and_403(path, {'frozen': True, 'description': 'test3'})
-        self.assert_patch_and_403(path, {'reserved': 4, 'frozen': True, 'description': 'test4'})


### PR DESCRIPTION
This PR removes all limitations for network admins with PATCH requests to the `/networks/<network>`. The current implementation is speculative in the limitations it imposes, and it assumes a use-case that is no longer relevant. 

With #572, we now interact with this endpoint with a broader range of requests than before, and as such it is no longer feasible to limit network admins' usage of it.